### PR TITLE
Add xenstore-1.0.0

### DIFF
--- a/packages/xenstore-1.0.0/descr
+++ b/packages/xenstore-1.0.0/descr
@@ -1,0 +1,1 @@
+Xenstore protocol clients and servers

--- a/packages/xenstore-1.0.0/opam
+++ b/packages/xenstore-1.0.0/opam
@@ -1,0 +1,10 @@
+opam-version: "1"
+maintainer: "dave.scott@eu.citrix.com"
+build: [
+  ["make" "all"]
+  ["make" "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "xenstore"]
+]
+depends: ["cstruct" "lwt" "ounit" "ocamlfind"]

--- a/packages/xenstore-1.0.0/url
+++ b/packages/xenstore-1.0.0/url
@@ -1,0 +1,1 @@
+git: "git://github.com/djs55/ocaml-xenstore"


### PR DESCRIPTION
I tried to test this by:
  opam init default  http://mirage.github.com/opam-0.4
  opam remote -add djs git://github.com/djs55/opam-repo-dev
  opam install xenstore

but it didn't find it -- I'm not sure why.

Anyway, I manually installed the declared dependencies on a fresh checkout and the build worked ok for me.
