### PR TITLE
Add mirage-net as a dependency of mirage-www

### DIFF
--- a/packages/mirage-www.0.3.0/opam
+++ b/packages/mirage-www.0.3.0/opam
@@ -4,4 +4,4 @@ build: [
   ["make" "all"]
 ]
 remove: [ ]
-depends: [ "mirage-fs" "ocamlfind" "cohttp" "mirage" "re" "cow" ] 
+depends: [ "mirage-net" "mirage-fs" "ocamlfind" "cohttp" "mirage" "re" "cow" ] 


### PR DESCRIPTION
mirage-www needs cohttp.mirage which is only built if mirage-net is installed.
