### PR TITLE
Add xen-block-driver.0.2.0 and xen-disk.1.0.0

### DIFF
--- a/packages/xen-block-driver.0.2.0/descr
+++ b/packages/xen-block-driver.0.2.0/descr
@@ -1,0 +1,1 @@
+Xen disk device drivers: both client ("frontend") and server ("backend")

--- a/packages/xen-block-driver.0.2.0/opam
+++ b/packages/xen-block-driver.0.2.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1"
+maintainer: "dave.scott@eu.citrix.com"
+build: [
+  [make]
+  [make "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  [make "uninstall" "BINDIR=%{bin}%"]
+]
+depends: [
+  "ocamlfind"
+  "cmdliner"
+  "lwt"
+  "cstruct"
+  "shared-memory-ring" {>= "0.4.0"}
+  "mirage"
+]
+depopts: [
+  "xenctrl"
+]

--- a/packages/xen-block-driver.0.2.0/url
+++ b/packages/xen-block-driver.0.2.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-xen-block-driver/archive/0.2.0.tar.gz"
+checksum: "405b50caa96d4a44164d85f76c8f1301"

--- a/packages/xen-disk.1.0.0/descr
+++ b/packages/xen-disk.1.0.0/descr
@@ -1,0 +1,1 @@
+A command-line tool for attaching disks to VMs running on a xen host.

--- a/packages/xen-disk.1.0.0/opam
+++ b/packages/xen-disk.1.0.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1"
+maintainer: "dave.scott@eu.citrix.com"
+build: [
+  ["make"]
+  ["make" "install" "BINDIR=%{bin}%"]
+]
+remove: [
+  ["make" "uninstall" "BINDIR=%{bin}%"]
+]
+depends: [
+  "ocamlfind"
+  "obuild"
+  "mirage-unix"
+  "xen-block-driver" {>= "0.2.0"}
+  "xenctrl" {>="5.0.0"}
+  "xenstore"
+  "xenstore_transport"
+  "vhd"
+  "cmdliner"
+]

--- a/packages/xen-disk.1.0.0/url
+++ b/packages/xen-disk.1.0.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/xen-disk/archive/1.0.0.tar.gz"
+checksum: "15bc9d9f83701f4681b0a6d9b320821f"


### PR DESCRIPTION
These packages are both released but I still need to release some of their dependencies (e.g. vhd, mirage tip) before they can be pushed upstream to OCamlPro/opam-repository.
