### PR TITLE
mirage-xen: depend on conf-pkg-config

### DIFF
--- a/packages/mirage-xen/mirage-xen.2.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.2.0.0/opam
@@ -16,9 +16,7 @@ depends: [
   "xen-evtchn" {>="0.9.9"}
   "xen-gnt" {>="2.0.0"}
   "mirage-xen-minios"
+  "conf-pkg-config"
 ]
 ocaml-version: [>= "4.00.0" & < "4.02.0"]
 os: ["linux"]
-depexts: [
-  [["ubuntu"] ["pkg-config"]]
-]


### PR DESCRIPTION
The conf-pkg-config has more depext information than the mirage-xen
package has, and is likely to be kept up to date.

Signed-off-by: David Scott dave.scott@eu.citrix.com
