### PR TITLE
vchan should depend on xenstore_transport as well as xenstore

### DIFF
--- a/packages/vchan/vchan.2.0.0/opam
+++ b/packages/vchan/vchan.2.0.0/opam
@@ -19,11 +19,11 @@ depends: [
   "io-page"
   "mirage-types-lwt"
   "xenstore" {>= "1.2.2"}
+  "xenstore_transport"
   "sexplib"
   "cmdliner"
 ]
 depopts: [
-  "xenstore_transport"
   "xen-evtchn" {>= "1.0.3"}
   "xen-gnt"
   "mirage-xen"


### PR DESCRIPTION
Probably these packages should be merged. Xenstore_transport doesn't
depend on anything else significant.

Signed-off-by: David Scott dave.scott@eu.citrix.com
