### PR TITLE
add asn1/mirage-entropy-xen/nocrypto/tls/x509 which might work out of the box

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.1.2/descr
+++ b/packages/asn1-combinators/asn1-combinators.0.1.2/descr
@@ -1,0 +1,3 @@
+Combinators for expressing ASN.1 grammars in OCaml
+
+Allows construction of BER and DER parsers and serializers.

--- a/packages/asn1-combinators/asn1-combinators.0.1.2/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.1.2/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+name:         "asn1-combinators"
+version:      "0.1.2"
+homepage:     "https://github.com/mirleft/ocaml-asn1-combinators"
+dev-repo:     "https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports:  "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+author:       "David Kaloper <david@numm.org>"
+maintainer:   "David Kaloper <david@numm.org>"
+license:      "BSD2"
+
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix ]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "asn1-combinators"]
+
+depends: [
+  "ocamlfind"
+  "cstruct" {>= "1.2.0"}
+  "zarith"
+]
+tags: [ "org:mirage" ]
+available: [ ocaml-version >= "4.01.0" ]

--- a/packages/asn1-combinators/asn1-combinators.0.1.2/url
+++ b/packages/asn1-combinators/asn1-combinators.0.1.2/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirleft/ocaml-asn1-combinators/archive/0.1.2.tar.gz"
+checksum: "0d2d2d47610052ecc3991bd5e7767b1d"

--- a/packages/mirage-entropy-xen/mirage-entropy-xen.0.3.0/descr
+++ b/packages/mirage-entropy-xen/mirage-entropy-xen.0.3.0/descr
@@ -1,0 +1,1 @@
+Mirage entropy device

--- a/packages/mirage-entropy-xen/mirage-entropy-xen.0.3.0/opam
+++ b/packages/mirage-entropy-xen/mirage-entropy-xen.0.3.0/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name:         "mirage-entropy-xen"
+version:      "0.3.0"
+homepage:     "https://github.com/mirage/mirage-entropy"
+dev-repo:     "https://github.com/mirage/mirage-entropy.git"
+bug-reports:  "https://github.com/mirage/mirage-entropy/issues"
+author:       ["Hannes Mehnert" "David Kaloper" "Anil Madhavapeddy" "Dave Scott"]
+maintainer:   "david@numm.org"
+license:      "BSD2"
+
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [make "install"]
+remove: [
+  ["ocamlfind" "remove" "mirage-entropy-xen"]
+]
+depends: [
+  "ocamlfind"
+  "cstruct" {>= "1.4.0"}
+  "mirage-xen" {>="2.2.0"}
+]
+tags: [ "org:mirage"]
+available: [ ocaml-version >= "4.01.0" ]

--- a/packages/mirage-entropy-xen/mirage-entropy-xen.0.3.0/url
+++ b/packages/mirage-entropy-xen/mirage-entropy-xen.0.3.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/mirage-entropy/archive/0.3.0.tar.gz"
+checksum: "6259cd4df8e0fe088e1d81a19c7f2944"

--- a/packages/nocrypto/nocrypto.0.4.0/descr
+++ b/packages/nocrypto/nocrypto.0.4.0/descr
@@ -1,0 +1,6 @@
+Small functional-style crypto library.
+
+Ciphers: AES, 3DES, RC4.
+Hashes: MD5, SHA1, SHA2.
+Pubkey: RSA, DH, DSA.
+Rng: Fortuna.

--- a/packages/nocrypto/nocrypto.0.4.0/opam
+++ b/packages/nocrypto/nocrypto.0.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+name:         "nocrypto"
+version:      "0.4.0"
+homepage:     "https://github.com/mirleft/ocaml-nocrypto"
+dev-repo:     "https://github.com/mirleft/ocaml-nocrypto.git"
+bug-reports:  "https://github.com/mirleft/ocaml-nocrypto/issues"
+author:       "David Kaloper <david@numm.org>"
+maintainer:   "David Kaloper <david@numm.org>"
+license:      "BSD2"
+
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix
+    "--%{lwt:enable}%-lwt"
+    "--%{mirage-xen:enable}%-xen" ]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove:  ["ocamlfind" "remove" "nocrypto"]
+
+depends: [
+  "ocamlfind"
+  "cstruct" {>= "1.4.0"}
+  "zarith"
+  "type_conv"
+  "sexplib"
+  "ctypes" {>= "0.3.3"}
+]
+
+depopts: [
+  "lwt"
+  "mirage-xen"
+  "mirage-entropy-xen"
+]
+
+conflicts: [
+  "mirage-xen" {<"2.2.0"}
+  "mirage-entropy-xen" {<"0.3.0"}
+]
+
+tags: [ "org:mirage"]
+available: [ ocaml-version >= "4.01.0" ]

--- a/packages/nocrypto/nocrypto.0.4.0/opam
+++ b/packages/nocrypto/nocrypto.0.4.0/opam
@@ -11,7 +11,7 @@ license:      "BSD2"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix
     "--%{lwt:enable}%-lwt"
-    "--%{mirage-xen:enable}%-xen" ]
+    "--%{mirage-xen+mirage-entropy-xen:enable}%-xen" ]
   ["ocaml" "setup.ml" "-build"]
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/nocrypto/nocrypto.0.4.0/url
+++ b/packages/nocrypto/nocrypto.0.4.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirleft/ocaml-nocrypto/archive/0.4.0.tar.gz"
+checksum: "6b6cc5b748f785e04d03f207b0e10d66"

--- a/packages/tls/tls.0.5.0/descr
+++ b/packages/tls/tls.0.5.0/descr
@@ -1,0 +1,4 @@
+Transport Layer Security (TLS) in OCaml
+
+A clean-slate TLS implementation, with support for protocol versions 1.0-1.2.
+Includes the core library, as well as Lwt and Mirage frontends.

--- a/packages/tls/tls.0.5.0/opam
+++ b/packages/tls/tls.0.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "1.2"
+name:         "tls"
+version:      "0.5.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+author:       ["David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD2"
+
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix
+    "--%{lwt:enable}%-lwt"
+    "--%{mirage-types+io-page+ipaddr:enable}%-mirage" ]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "tls"]
+
+depends: [
+  "ocamlfind"
+  "cstruct" {>= "1.2.0"}
+  "type_conv"
+  "sexplib"
+  "nocrypto" {>= "0.4.0"}
+  "x509" {>= "0.3.0"}
+  "camlp4"
+]
+depopts: [
+  "lwt"
+  "mirage-types-lwt"
+]
+conflicts: [
+  "lwt" {<"2.4.8"}
+  "mirage-types-lwt" {<"2.3.0"}
+  "mirage-net-xen" {<"1.3.0"}
+]
+ocaml-version: [>="4.01.0"]

--- a/packages/tls/tls.0.5.0/url
+++ b/packages/tls/tls.0.5.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirleft/ocaml-tls/archive/0.5.0.tar.gz"
+checksum: "45a19a587179a65cf108d74c267c0692"

--- a/packages/x509/x509.0.3.1/descr
+++ b/packages/x509/x509.0.3.1/descr
@@ -1,0 +1,4 @@
+X.509 certificate (RFC5280) library
+
+Library for X.509 certificate parsing, serialization and authentication.
+Supports path validation (RFC5280) and hostname verification (RFC6125).

--- a/packages/x509/x509.0.3.1/opam
+++ b/packages/x509/x509.0.3.1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name:         "x509"
+version:      "0.3.1"
+homepage:     "https://github.com/mirleft/ocaml-x509"
+dev-repo:     "https://github.com/mirleft/ocaml-x509.git"
+bug-reports:  "https://github.com/mirleft/ocaml-x509/issues"
+author:       [ "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   [ "Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>" ]
+license:      "BSD2"
+
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix ]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+remove: ["ocamlfind" "remove" "x509"]
+
+depends: [
+  "ocamlfind"
+  "cstruct" {>= "1.2.0"}
+  "type_conv"
+  "sexplib"
+  "asn1-combinators" {>= "0.1.1"}
+  "nocrypto" {>= "0.2.0"}
+]
+tags: [ "org:mirage" ]
+available: [ ocaml-version >= "4.01.0" ]

--- a/packages/x509/x509.0.3.1/url
+++ b/packages/x509/x509.0.3.1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirleft/ocaml-x509/archive/0.3.1.tar.gz"
+checksum: "6afe09367fc21a2e365ca4309b3e88d6"


### PR DESCRIPTION
this is not being released to the main opam-repository yet since it might break stuff partially...
it awaits for: https://github.com/mirage/mirage/pull/394 and a solution for zarith & gmp (maybe https://github.com/mirage/mirage-dev/pull/63 is a start?)