### PR TITLE
Fix gmp-xen

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.1.2/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.1.2/opam
@@ -1,6 +1,4 @@
 opam-version: "1.2"
-name:         "asn1-combinators"
-version:      "0.1.2"
 homepage:     "https://github.com/mirleft/ocaml-asn1-combinators"
 dev-repo:     "https://github.com/mirleft/ocaml-asn1-combinators.git"
 bug-reports:  "https://github.com/mirleft/ocaml-asn1-combinators/issues"

--- a/packages/gmp-xen/gmp-xen.6.0.0/files/META
+++ b/packages/gmp-xen/gmp-xen.6.0.0/files/META
@@ -1,4 +1,0 @@
-version = "6.0.0"
-description = "The GNU Multiple Precision Arithmetic Library"
-linkopts = "-cclib -lgmp"
-xen_linkopts = "-lgmp_xen"

--- a/packages/gmp-xen/gmp-xen.6.0.0/files/gmp-xen.pc
+++ b/packages/gmp-xen/gmp-xen.6.0.0/files/gmp-xen.pc
@@ -1,11 +1,9 @@
-prefix=${pcfiledir}/../..
-exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+libdir=${pcfiledir}/../gmp-xen
+includedir=${libdir}/include
 
 Name: gmp-xen
 Version: 6.0.0
 URL: https://gmplib.org
 Description: The GNU Multiple Precision Arithmetic Library
 Cflags: -I${includedir}
-Libs: -L${libdir} -lgmp
+Libs: -L${libdir} -lgmp-xen

--- a/packages/gmp-xen/gmp-xen.6.0.0/files/mirage-build.sh
+++ b/packages/gmp-xen/gmp-xen.6.0.0/files/mirage-build.sh
@@ -9,8 +9,8 @@ CPPFLAGS="$CPPFLAGS `pkg-config mirage-xen --cflags` -O2 -pedantic -fomit-frame-
 # Pass CPPFLAGS (not just CFLAGS) to stop it finding the Linux headers (just generates warnings).
 # Use -Werror=missing-prototypes because we're not running the tests due to cross-compiling.
 HOST="`uname -m`-unknown-none"
-BUILD=`../config.guess`
-./configure --host="$HOST" --build="$BUILD" CC=gcc --prefix="$PREFIX/lib/gmp" --disable-shared CPPFLAGS="$CPPFLAGS"
+BUILD=`./config.guess`
+./configure --host="$HOST" --build="$BUILD" CC=gcc --prefix="$PREFIX/lib/gmp-xen" --disable-shared CPPFLAGS="$CPPFLAGS"
 # Because we're cross-compiling, configurate can't tell whether a function
 # actually exists and just assumes they all do. For localeconv, this is wrong.
 sed -e '/HAVE_LOCALECONV/d'  		\

--- a/packages/gmp-xen/gmp-xen.6.0.0/files/mirage-install.sh
+++ b/packages/gmp-xen/gmp-xen.6.0.0/files/mirage-install.sh
@@ -3,8 +3,8 @@ PREFIX=`opam config var prefix`
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
 export PKG_CONFIG_PATH
 
+make install
 mkdir -p "$PREFIX/lib/pkgconfig"
 cp gmp-xen.pc "$PREFIX/lib/pkgconfig/"
-
-ocamlfind install gmp-xen META
-cp .libs/libgmp.a "$PREFIX/lib/gmp/libgmp_xen.a"
+mkdir -p "$PREFIX/lib/gmp-xen"
+cp .libs/libgmp.a "$PREFIX/lib/gmp-xen/libgmp-xen.a"

--- a/packages/gmp-xen/gmp-xen.6.0.0/opam
+++ b/packages/gmp-xen/gmp-xen.6.0.0/opam
@@ -1,6 +1,4 @@
 opam-version: "1.2"
-name: "gmp-xen"
-version: "6.0.0"
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 homepage: "https://gmplib.org/"
 license: "GNU LGPL v3 and GNU GPL v2"
@@ -9,9 +7,8 @@ build: ["./mirage-build.sh"]
 install: ["./mirage-install.sh"]
 remove: [
    ["rm" "-rf"
-      "%{prefix}%/include/gmp.h"
-      "%{prefix}%/lib/pkgconfig/gmp.pc"
-      "%{prefix}%/lib/gmp" ]
+      "%{prefix}%/lib/pkgconfig/gmp-xen.pc"
+      "%{prefix}%/lib/gmp-xen" ]
  ]
 depends: [
   "mirage-xen"

--- a/packages/jitsu/jitsu.0.1/opam
+++ b/packages/jitsu/jitsu.0.1/opam
@@ -1,6 +1,4 @@
 opam-version: "1.2"
-name: "jitsu"
-version: "0.1"
 maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
 authors: "Magnus Skjegstad <magnus@skjegstad.com>"
 homepage: "https://github.com/MagnusS/jitsu"

--- a/packages/mirage-entropy-xen/mirage-entropy-xen.0.3.0/opam
+++ b/packages/mirage-entropy-xen/mirage-entropy-xen.0.3.0/opam
@@ -1,6 +1,4 @@
 opam-version: "1.2"
-name:         "mirage-entropy-xen"
-version:      "0.3.0"
 homepage:     "https://github.com/mirage/mirage-entropy"
 dev-repo:     "https://github.com/mirage/mirage-entropy.git"
 bug-reports:  "https://github.com/mirage/mirage-entropy/issues"

--- a/packages/mirage-nat/mirage-nat.0.2/opam
+++ b/packages/mirage-nat/mirage-nat.0.2/opam
@@ -1,6 +1,4 @@
 opam-version: "1.2"
-name: "mirage-nat"
-version: "0.2"
 maintainer: "Mindy Preston <meetup@yomimono.org>"
 authors: "Mindy Preston <meetup@yomimono.org>"
 homepage: "https://github.com/yomimono/mirage-nat"

--- a/packages/mirage-profile/mirage-profile.0.1/opam
+++ b/packages/mirage-profile/mirage-profile.0.1/opam
@@ -1,6 +1,4 @@
 opam-version: "1.2"
-name: "mirage-profile"
-version: "0.1"
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 authors: "Thomas Leonard <talex5@gmail.com>"
 homepage: "https://github.com/mirage/mirage-profile"

--- a/packages/mirage-vnetif/mirage-vnetif.0.1/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.1/opam
@@ -1,6 +1,4 @@
 opam-version: "1.2"
-name: "mirage-vnetif"
-version: "0.1"
 maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
 authors: "Magnus Skjegstad <magnus@skjegstad.com>"
 homepage: "https://github.com/MagnusS/mirage-vnetif"

--- a/packages/nocrypto/nocrypto.0.4.0/opam
+++ b/packages/nocrypto/nocrypto.0.4.0/opam
@@ -1,6 +1,4 @@
 opam-version: "1.2"
-name:         "nocrypto"
-version:      "0.4.0"
 homepage:     "https://github.com/mirleft/ocaml-nocrypto"
 dev-repo:     "https://github.com/mirleft/ocaml-nocrypto.git"
 bug-reports:  "https://github.com/mirleft/ocaml-nocrypto/issues"

--- a/packages/tls/tls.0.5.0/opam
+++ b/packages/tls/tls.0.5.0/opam
@@ -1,6 +1,4 @@
 opam-version: "1.2"
-name:         "tls"
-version:      "0.5.0"
 homepage:     "https://github.com/mirleft/ocaml-tls"
 dev-repo:     "https://github.com/mirleft/ocaml-tls.git"
 bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"

--- a/packages/x509/x509.0.3.1/opam
+++ b/packages/x509/x509.0.3.1/opam
@@ -1,6 +1,4 @@
 opam-version: "1.2"
-name:         "x509"
-version:      "0.3.1"
 homepage:     "https://github.com/mirleft/ocaml-x509"
 dev-repo:     "https://github.com/mirleft/ocaml-x509.git"
 bug-reports:  "https://github.com/mirleft/ocaml-x509/issues"

--- a/packages/zarith/zarith.1.3/files/mirage-install.sh
+++ b/packages/zarith/zarith.1.3/files/mirage-install.sh
@@ -15,5 +15,5 @@ if pkg-config --exists mirage-xen; then
   export CFLAGS
   ./configure
   make
-  cp libzarith.a "$PREFIX/lib/zarith/libzarith_xen.a"
+  cp libzarith.a "$PREFIX/lib/zarith/libzarith-xen.a"
 fi

--- a/packages/zarith/zarith.1.3/files/xen_linkopts.patch
+++ b/packages/zarith/zarith.1.3/files/xen_linkopts.patch
@@ -6,4 +6,4 @@ index c082c65..14394d1 100644
  version = "1.3"
  archive(byte) = "zarith.cma"
  archive(native) = "zarith.cmxa"
-+xen_linkopts = "-lzarith_xen"
++xen_linkopts = "-lgmp-xen -lzarith-xen"

--- a/packages/zarith/zarith.1.3/files/xen_linkopts.patch
+++ b/packages/zarith/zarith.1.3/files/xen_linkopts.patch
@@ -6,4 +6,4 @@ index c082c65..14394d1 100644
  version = "1.3"
  archive(byte) = "zarith.cma"
  archive(native) = "zarith.cmxa"
-+xen_linkopts = "-lgmp-xen -lzarith-xen"
++xen_linkopts = "-lzarith-xen -L@gmp-xen -lgmp-xen"


### PR DESCRIPTION
I've changed a little bit how we do things, using `ocamlfind` to handle the overlay C dependencies was not a so good idea. The current `xen_linkopts` scheme is not very satisfactory, but well, it works... 