### PR TITLE
depend on mirage-xen-posix, instead of mirage-xen. the latter depends

### DIFF
--- a/packages/gmp-xen/gmp-xen.6.0.0/files/mirage-build.sh
+++ b/packages/gmp-xen/gmp-xen.6.0.0/files/mirage-build.sh
@@ -3,7 +3,7 @@ PREFIX=`opam config var prefix`
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
 export PKG_CONFIG_PATH
 
-CPPFLAGS="$CPPFLAGS `pkg-config mirage-xen --cflags` -O2 -pedantic -fomit-frame-pointer -fno-builtin -D_FORTIFY_SOURCE=0 -Wmissing-prototypes --std=gnu99"
+CPPFLAGS="$CPPFLAGS `pkg-config mirage-xen-posix --cflags` -O2 -pedantic -fomit-frame-pointer -fno-builtin -D_FORTIFY_SOURCE=0 -Wmissing-prototypes --std=gnu99"
 # Use different --host and --build to trigger cross-compilation mode (don't try to test binaries during configure)
 # Set CC to stop it trying to find a separate compiler for HOST.
 # Pass CPPFLAGS (not just CFLAGS) to stop it finding the Linux headers (just generates warnings).

--- a/packages/gmp-xen/gmp-xen.6.0.0/opam
+++ b/packages/gmp-xen/gmp-xen.6.0.0/opam
@@ -12,5 +12,5 @@ remove: [
     "%{prefix}%/lib/gmp-xen"
 ]
 depends: [
-  "mirage-xen"
+  "mirage-xen-posix"
 ]


### PR DESCRIPTION
on cstruct etc., whereas gmp-xen only needs some CFLAGS and include
files. minimizes recompilations