### PR TITLE
also build on 4.02

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ os:
 env:
   matrix:
     - OCAML_VERSION=4.01.0
+    - OCAML_VERSION=4.02.0


### PR DESCRIPTION
this was disabled in October 2014, but mirage-xen works with ocaml 4.2 since 2.2.0, thus re-enabling