### PR TITLE
gmp: build cpu autodetection

### DIFF
--- a/packages/gmp-xen/gmp-xen.6.0.0/files/mirage-build.sh
+++ b/packages/gmp-xen/gmp-xen.6.0.0/files/mirage-build.sh
@@ -10,7 +10,7 @@ CPPFLAGS="$CPPFLAGS `pkg-config mirage-xen-posix --cflags` -O2 -pedantic -fomit-
 # Use -Werror=missing-prototypes because we're not running the tests due to cross-compiling.
 HOST="`uname -m`-unknown-none"
 BUILD=`./config.guess`
-./configure --host="$HOST" --build="$BUILD" CC=gcc --prefix="$PREFIX/lib/gmp-xen" --disable-shared CPPFLAGS="$CPPFLAGS"
+./configure --host="$HOST" --build="$BUILD" --enable-fat CC=gcc --prefix="$PREFIX/lib/gmp-xen" --disable-shared CPPFLAGS="$CPPFLAGS"
 # Because we're cross-compiling, configurate can't tell whether a function
 # actually exists and just assumes they all do. For localeconv, this is wrong.
 sed -e '/HAVE_LOCALECONV/d'  \


### PR DESCRIPTION
GMP contains specific support for about a dozen generations per cpu architecture, but normally only compiles in what was detected as the target platform via `config.guess`. On x86 and x86_64, it can instead be compiled with all the generations and a cpu-detection shim.

The effect is to bump the `.a` from 1.2MB to 1.4MB. I didn't measure the performance hit, but at some point in the past I found it to be about 15% for mildly divergent build vs. run machines.