### PR TITLE
Include packages that needed CLOCK API updates.

### DIFF
--- a/packages/mirage-clock-unix/mirage-clock-unix.dev~mirage/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.dev~mirage/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+authors: "The MirageOS team"
+maintainer: "anil@recoil.org"
+homepage: "https://github.com/mirage/mirage-clock"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [make "unix-build"]
+install: [make "unix-install"]
+remove: ["ocamlfind" "remove" "mirage-clock-unix"]
+depends: [
+  "ocamlfind"
+  "mirage-types" {>= "0.3.0"}
+]
+dev-repo: "git://github.com/mirage/mirage-clock"

--- a/packages/mirage-clock-unix/mirage-clock-unix.dev~mirage/url
+++ b/packages/mirage-clock-unix/mirage-clock-unix.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mirage/mirage-clock.git"

--- a/packages/mirage-clock-xen/mirage-clock-xen.dev~mirage/opam
+++ b/packages/mirage-clock-xen/mirage-clock-xen.dev~mirage/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+authors: "The MirageOS team"
+maintainer: "anil@recoil.org"
+homepage: "https://github.com/mirage/mirage-clock"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [make "xen-build"]
+install: [make "xen-install"]
+remove: ["ocamlfind" "remove" "mirage-clock-xen"]
+depends: [
+  "ocamlfind"
+  "mirage-types" {>= "0.3.0"}
+]
+dev-repo: "git://github.com/mirage/mirage-clock"

--- a/packages/mirage-clock-xen/mirage-clock-xen.dev~mirage/url
+++ b/packages/mirage-clock-xen/mirage-clock-xen.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mirage/mirage-clock.git"

--- a/packages/mirage-flow/mirage-flow.dev~mirage/opam
+++ b/packages/mirage-flow/mirage-flow.dev~mirage/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: [ "Thomas Gazagnaire <thomas@gazagnaire.org>" "David Scott <dave@recoil.org>" ]
+version: "1.1.0"
+homepage: "https://github.com/mirage/mirage-flow"
+bug-reports: "https://github.com/mirage/mirage-flow/issues/"
+license: "ISC"
+dev-repo: "https://github.com/mirage/mirage-flow.git"
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make]
+]
+build-test: [
+  ["./configure" "--prefix=%{prefix}%" "--enable-tests"]
+  [make "test"]
+]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "mirage-flow"]
+depends: [
+  "ocamlbuild" {build}
+  "ocamlfind"  {build}
+  "mirage-types-lwt"
+  "cstruct"
+  "lwt" {>= "2.5.0"}
+  "alcotest" {test}
+  "ounit"    {test}
+]

--- a/packages/mirage-flow/mirage-flow.dev~mirage/url
+++ b/packages/mirage-flow/mirage-flow.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mirage/mirage-flow.git"

--- a/packages/mirage-logs/mirage-logs.dev~mirage/opam
+++ b/packages/mirage-logs/mirage-logs.dev~mirage/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "talex5@gmail.com"
+authors: [ "Thomas Leonard" ]
+license: "ISC"
+homepage: "https://github.com/mirage/mirage-logs"
+dev-repo: "https://github.com/mirage/mirage-logs.git"
+bug-reports: "https://github.com/mirage/mirage-logs/issues"
+
+build: [
+  [make "PREFIX=%{prefix}%"]
+]
+
+install: [make "PREFIX=%{prefix}%" "install"]
+
+remove: [["ocamlfind" "remove" "mirage-logs"]]
+
+depends: [
+  "logs" { >= "0.5.0" }
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ptime"
+  "mirage-types"
+  "mirage-profile"
+  "lwt"
+]
+
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage-logs/mirage-logs.dev~mirage/url
+++ b/packages/mirage-logs/mirage-logs.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mirage/mirage-logs.git"


### PR DESCRIPTION
These pins are needed to build now that V1.CLOCK is no more.