### PR TITLE
Travis updates (skeleton script, use trusty, add Solo5)

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,33 +1,15 @@
-# Install OCaml and OPAM PPAs
-case "$OCAML_VERSION" in
-  4.02) ppa=avsm/ocaml42+opam12 ;;
-  *) echo Unknown $OCAML_VERSION; exit 1 ;;
-esac
-
-echo "yes" | sudo add-apt-repository ppa:$ppa
-sudo apt-get update -qq
-sudo apt-get install -qq ocaml ocaml-native-compilers camlp4-extra opam time libgmp-dev
-
-TRUSTY="deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe"
-sudo add-apt-repository "${TRUSTY}"
-sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-sudo apt-get -qq update
-sudo apt-get -qq install gcc-4.8
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
-sudo add-apt-repository -r "${TRUSTY}"
-
-echo OCaml version
-ocaml -version
+bash .travis-ocaml.sh
 
 export OPAMYES=1
+eval $(opam config env)
 
-opam init git://github.com/ocaml/opam-repository >/dev/null 2>&1
 opam repo add mirage-dev .
 opam update -u
-
 opam install mirage
-eval `opam config env`
+
 git clone -b mirage-dev git://github.com/mirage/mirage-skeleton
 cd mirage-skeleton
 MODE=unix make
 MODE=xen make
+MODE=ukvm make
+MODE=virtio make

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -9,7 +9,4 @@ opam install mirage
 
 git clone -b mirage-dev git://github.com/mirage/mirage-skeleton
 cd mirage-skeleton
-MODE=unix make
-MODE=xen make
-MODE=ukvm make
-MODE=virtio make
+make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: c
-script: bash -e .travis-ci.sh
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-ocaml.sh
+script: bash -ex .travis-ci.sh
 sudo: required
-os:
-- linux
+dist: trusty
 env:
   matrix:
+    - OCAML_VERSION=4.03
     - OCAML_VERSION=4.02

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,11 @@ sudo: required
 dist: trusty
 env:
   matrix:
-    - OCAML_VERSION=4.03
-    - OCAML_VERSION=4.02
+    - OCAML_VERSION=4.03 MODE=unix
+    - OCAML_VERSION=4.03 MODE=xen
+    - OCAML_VERSION=4.03 MODE=ukvm
+    - OCAML_VERSION=4.03 MODE=virtio
+    - OCAML_VERSION=4.02 MODE=unix
+    - OCAML_VERSION=4.02 MODE=xen
+    - OCAML_VERSION=4.02 MODE=ukvm
+    - OCAML_VERSION=4.02 MODE=virtio


### PR DESCRIPTION
- Use ocaml-travisci-skeleton/travis-ocaml.sh instead of custom script.
- Run on Ubuntu Trusty (14.04). 12.04 is ancient and mirage-dev is
  supposed to be a testbed for "latest master".
- Add Solo5 targets (ukvm, virtio).
- Add Ocaml 4.03.0.