### PR TITLE
fat-filesystem version 11 

### DIFF
--- a/packages/fat-filesystem/fat-filesystem.0.11.0/descr
+++ b/packages/fat-filesystem/fat-filesystem.0.11.0/descr
@@ -1,0 +1,4 @@
+FAT filesystem implementation
+
+This allows FAT-formatted data to be read and written from
+a MirageOS BLOCK device.

--- a/packages/fat-filesystem/fat-filesystem.0.11.0/findlib
+++ b/packages/fat-filesystem/fat-filesystem.0.11.0/findlib
@@ -1,0 +1,1 @@
+fat-filesystem

--- a/packages/fat-filesystem/fat-filesystem.0.11.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.11.0/opam
@@ -1,0 +1,33 @@
+opam-version: "1.2"
+authors: ["Dave Scott" "Anil Madhavapeddy"]
+maintainer: "dave@recoil.org"
+homepage:     "https://github.com/mirage/ocaml-fat"
+bug-reports:  "https://github.com/mirage/ocaml-fat/issues"
+dev-repo:     "https://github.com/mirage/ocaml-fat.git"
+build: [
+  ["./configure" "--bindir" "%{bin}%"]
+  [make]
+]
+install: [ [make "install"] ]
+remove: [
+  ["./configure" "--bindir" "%{bin}%"]
+  [make "uninstall"]
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "cstruct" {>= "2.0.0"}
+  "ppx_tools"
+  "lwt" {>= "2.4.3"}
+  "mirage-types" {>= "2.6.1"}
+  "mirage-block-unix" {>= "1.2.0"}
+  "io-page" {>= "1.6.1"}
+  "re"
+  "ounit"
+  "cmdliner"
+]
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+available: [ ocaml-version >= "4.02.3" ]

--- a/packages/fat-filesystem/fat-filesystem.0.11.0/url
+++ b/packages/fat-filesystem/fat-filesystem.0.11.0/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/mirage/ocaml-fat/archive/0.11.0.tar.gz"
+checksum: "e9c4de414d2fa1b77bb132ddb4b14062"


### PR DESCRIPTION
(can be removed once this is merged into opam-repository, see https://github.com/ocaml/opam-repository/pull/7399 )