### PR TITLE
fix inconsistent version number error

### DIFF
--- a/packages/charrua-core/charrua-core.dev~mirage/opam
+++ b/packages/charrua-core/charrua-core.dev~mirage/opam
@@ -1,6 +1,5 @@
 opam-version: "1.2"
 name: "charrua-core"
-version: "0.3"
 maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
 authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
 homepage: "https://github.com/haesbaert/charrua-core"

--- a/packages/mirage-flow/mirage-flow.dev~mirage/opam
+++ b/packages/mirage-flow/mirage-flow.dev~mirage/opam
@@ -1,7 +1,6 @@
 opam-version: "1.2"
 maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
 authors: [ "Thomas Gazagnaire <thomas@gazagnaire.org>" "David Scott <dave@recoil.org>" ]
-version: "1.1.0"
 homepage: "https://github.com/mirage/mirage-flow"
 bug-reports: "https://github.com/mirage/mirage-flow/issues/"
 license: "ISC"


### PR DESCRIPTION
the `version` field will cause opam to produce an error complaining about inconsistent version number, after `opam remote add`, the universe won't include the dev~mirage version then