### PR TITLE
KV_RO mem changes

### DIFF
--- a/packages/fat-filesystem/fat-filesystem.dev~mirage/opam
+++ b/packages/fat-filesystem/fat-filesystem.dev~mirage/opam
@@ -18,6 +18,7 @@ depends: [
   "ocamlbuild" {build}
   "cstruct" {>= "2.0.0"}
   "ppx_tools"
+  "rresult"
   "lwt" {>= "2.4.3"}
   "mirage-types" {>= "2.6.1"}
   "mirage-block-unix" {>= "1.2.0"}

--- a/packages/irmin/irmin.dev~mirage/url
+++ b/packages/irmin/irmin.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/avsm/irmin#mirage3"
+git: "git://github.com/yomimono/irmin#mem-in-kvro"

--- a/packages/protocol-9p/protocol-9p.dev~mirage/opam
+++ b/packages/protocol-9p/protocol-9p.dev~mirage/opam
@@ -1,0 +1,43 @@
+opam-version: "1.2"
+maintainer:   "dave@recoil.org"
+authors:      [ "David Scott" "David Sheets" "Thomas Leonard" ]
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-9p"
+dev-repo:     "https://github.com/mirage/ocaml-9p.git"
+bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
+doc:          "https://mirage.github.io/ocaml-9p/"
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" pinned
+          "--with-lambda-term" lambda-term:installed]
+
+build-test: [
+  ["ocaml" "pkg/pkg.ml" "build" "--tests" "true"
+     "--with-lambda-term" lambda-term:installed]
+  ["ocaml" "pkg/pkg.ml" "test"]
+]
+
+depends: [
+  "base-bytes"
+  "cstruct" {>= "1.9.0"}
+  "sexplib" {> "113.00.00" }
+  "result"
+  "mirage-types-lwt"
+  "channel" {>= "1.1.0" }
+  "lwt" {>= "2.4.7"}
+  "base-unix"
+  "cmdliner"
+  "astring"
+  "named-pipe"
+  "fmt"
+  "logs" {>= "0.5.0"}
+  "win-error"
+  "ppx_deriving" {build}
+  "ppx_sexp_conv" {build}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "ppx_tools" {build}
+  "topkg" {build & >= "0.7.3"}
+  "alcotest" {test & >= "0.4.0"}
+]
+depopts: ["lambda-term"]
+available: [ocaml-version >= "4.02.0"]

--- a/packages/protocol-9p/protocol-9p.dev~mirage/opam
+++ b/packages/protocol-9p/protocol-9p.dev~mirage/opam
@@ -7,7 +7,7 @@ dev-repo:     "https://github.com/mirage/ocaml-9p.git"
 bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
-build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" pinned
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "true"
           "--with-lambda-term" lambda-term:installed]
 
 build-test: [

--- a/packages/protocol-9p/protocol-9p.dev~mirage/url
+++ b/packages/protocol-9p/protocol-9p.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mirage/ocaml-9p.git"


### PR DESCRIPTION
add `rresult` to `fat-filesystem` dependencies, use the `mem-in-kvro` branch for Irmin, and use the current master of `protocol-9p`.