### PR TITLE
fix opam file typo

### DIFF
--- a/packages/mirage/mirage.dev~mirage/opam
+++ b/packages/mirage/mirage.dev~mirage/opam
@@ -9,7 +9,7 @@ dev-repo:     "https://github.com/mirage/mirage.git"
 tags:         ["org:mirage" "org:xapi-project"]
 doc:          "https://mirage.github.io/mirage/"
 
-build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" pinned]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 
 depends: [
   "ocamlbuild" {build}


### PR DESCRIPTION
got this error while trying to install mirage 
```
pkg.ml: [ERROR] key --pinned: No value specified
```