### PR TITLE
update opam for mirage-bootvar-xen

### DIFF
--- a/packages/mirage-bootvar-xen/mirage-bootvar-xen.dev~mirage/opam
+++ b/packages/mirage-bootvar-xen/mirage-bootvar-xen.dev~mirage/opam
@@ -7,20 +7,14 @@ bug-reports: "https://github.com/mirage/mirage-bootvar-xen/issues/"
 dev-repo: "https://github.com/mirage/mirage-bootvar-xen.git"
 license: "ISC"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--disable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-]
-build-test: [
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-test"]
-]
-install: [make "install"]
-remove: [
-  ["ocamlfind" "remove" "mirage-bootvar"]
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 ]
 depends: [
   "mirage-xen" { >= "2.2.0" }
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "lwt"
   "astring"
   "parse-argv"
 ]


### PR DESCRIPTION
See https://github.com/mirage/mirage-bootvar-xen/pull/29 .