### PR TITLE
remove build-test from mirage-net-unix for now

### DIFF
--- a/packages/mirage-net-unix/mirage-net-unix.dev~mirage/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.dev~mirage/opam
@@ -12,10 +12,6 @@ dev-repo:    "https://github.com/mirage/mirage-net-unix.git"
 license:     "ISC"
 
 build:   [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
-build-test: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]
-  [ "ocaml" "pkg/pkg.ml" "test" ]
-]
 depends: [
   "cstruct" {>= "1.7.1"}
   "ocamlfind" {build}


### PR DESCRIPTION
mirage-net-unix's `.travis.yml` specifies that the tests need to be run as root, but that (obviously) doesn't get inherited by other procedures that are running the tests as a side effect of `opam install -t` (see https://travis-ci.org/mirage/mirage/jobs/171098959 for an example).  For now, remove the `build-test` instructions for mirage-net-unix in mirage-dev.