### PR TITLE
Update crypto and everything around it

### DIFF
--- a/packages/cpuid/cpuid.dev~mirage/descr
+++ b/packages/cpuid/cpuid.dev~mirage/descr
@@ -1,0 +1,6 @@
+Detect CPU features
+
+
+cpuid allows detection of CPU features from OCaml.
+
+cpuid is distributed under the ISC license.

--- a/packages/cpuid/cpuid.dev~mirage/opam
+++ b/packages/cpuid/cpuid.dev~mirage/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/cpuid"
+doc: "https://pqwy.github.io/cpuid/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/cpuid.git"
+bug-reports: "https://github.com/pqwy/cpuid/issues"
+tags: []
+available: [ ocaml-version >= "4.02.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build}
+  "result" ]
+depopts: []
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]

--- a/packages/cpuid/cpuid.dev~mirage/url
+++ b/packages/cpuid/cpuid.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "git://github.com/pqwy/cpuid.git"

--- a/packages/mirage-entropy/mirage-entropy.dev~mirage/descr
+++ b/packages/mirage-entropy/mirage-entropy.dev~mirage/descr
@@ -1,0 +1,1 @@
+MirageOS entropy device

--- a/packages/mirage-entropy/mirage-entropy.dev~mirage/opam
+++ b/packages/mirage-entropy/mirage-entropy.dev~mirage/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+name:         "mirage-entropy"
+homepage:     "https://github.com/mirage/mirage-entropy"
+dev-repo:     "https://github.com/mirage/mirage-entropy.git"
+bug-reports:  "https://github.com/mirage/mirage-entropy/issues"
+author:       ["Hannes Mehnert" "David Kaloper" "Anil Madhavapeddy" "Dave Scott"]
+maintainer:   "david@numm.org"
+license:      "BSD2"
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+          "--tests" "false"
+          "--pinned" "%{pinned}%"
+          "--with-mirage-xen" "%{mirage-xen:installed}%"
+          "--with-mirage-solo5" "%{mirage-solo5:installed}%"
+          "--with-ocaml-freestanding" "%{ocaml-freestanding:installed}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.7.6"}
+  "ocb-stubblr" {build}
+  "cstruct" {>= "1.4.0"}
+  "mirage-os-shim"
+  "lwt"
+]
+depopts: [
+  "mirage-solo5"
+  "ocaml-freestanding"
+  "mirage-xen"
+]
+conflicts: [
+  "mirage-xen" {<"2.2.0"}
+]
+tags: [ "org:mirage"]
+available: [ ocaml-version >= "4.01.0" ]

--- a/packages/mirage-entropy/mirage-entropy.dev~mirage/url
+++ b/packages/mirage-entropy/mirage-entropy.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "git://github.com/mirage/mirage-entropy.git"

--- a/packages/mirage-os-shim/mirage-os-shim.dev~mirage/descr
+++ b/packages/mirage-os-shim/mirage-os-shim.dev~mirage/descr
@@ -1,0 +1,23 @@
+Portable shim for MirageOS APIs
+
+
+mirage-os-shim is the intersection of the Mirage OS APIs exported under the `OS`
+modules by various Mirage backends. It shims out this interface under the same
+`cmi`, and installs several implementations, that pass through to their
+respective backends.
+
+Clients need to be compiled against the common `mirage_OS.cmi`, and use the
+module `Mirage_OS`. Final applications need to be linked using `ocamlfind`, and
+have to define one of the `ocamlfind` predicates corresponding to the actual
+`OS` implementations: `mirage_unix`, `mirage_xen`, or `mirage_solo5`.
+
+When using `ocamlbuild`, this is
+`ocamlfind -use-ocamlfind -tag 'predicate(unix)'` or similar.
+
+**WARNING** Direct access to the `OS` interface is largely deprecated. The
+interface is pretty volatile. It is highly likely that you, in fact, do not need
+this package at all.
+
+mirage-os-shim is distributed under the ISC license.
+
+[![Build Status](https://travis-ci.org/pqwy/mirage-os-shim.svg?branch=master)](https://travis-ci.org/pqwy/mirage-os-shim)

--- a/packages/mirage-os-shim/mirage-os-shim.dev~mirage/opam
+++ b/packages/mirage-os-shim/mirage-os-shim.dev~mirage/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/mirage-os-shim"
+doc: "https://pqwy.github.io/mirage-os-shim/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/mirage-os-shim.git"
+bug-reports: "https://github.com/pqwy/mirage-os-shim/issues"
+tags: []
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+          "--tests" "false"
+          "--with-mirage-unix" "%{mirage-unix:installed}%"
+          "--with-mirage-xen" "%{mirage-xen:installed}%"
+          "--with-mirage-solo5" "%{mirage-solo5:installed}%"
+]
+build-test: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+          "--with-mirage-unix" "%{mirage-unix:installed}%"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mirage-unix"
+]
+depopts: [
+  "mirage-solo5"
+  "mirage-xen"
+]
+available: [ ocaml-version >= "4.01.0"]
+# conflicts: ["mirage-types" {< "3.0.0"}]

--- a/packages/mirage-os-shim/mirage-os-shim.dev~mirage/url
+++ b/packages/mirage-os-shim/mirage-os-shim.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "git://github.com/pqwy/mirage-os-shim.git"

--- a/packages/nocrypto/nocrypto.dev~mirage/opam
+++ b/packages/nocrypto/nocrypto.dev~mirage/opam
@@ -2,46 +2,31 @@ opam-version: "1.2"
 homepage:     "https://github.com/mirleft/ocaml-nocrypto"
 dev-repo:     "https://github.com/mirleft/ocaml-nocrypto.git"
 bug-reports:  "https://github.com/mirleft/ocaml-nocrypto/issues"
-author:       "David Kaloper <david@numm.org>"
+authors:      ["David Kaloper <david@numm.org>"]
 maintainer:   "David Kaloper <david@numm.org>"
-license:      "BSD2"
+license:      "ISC"
+tags:          [ "org:mirage" ]
+available:     [ ocaml-version >= "4.02.0" ]
 
-build: [
-  [ "./configure" "--prefix" prefix
-     "--%{lwt:enable}%-lwt"
-     "--%{mirage-xen+mirage-entropy-xen:enable}%-xen"
-     "--%{mirage-solo5+mirage-entropy-solo5:enable}%-solo5" ]
-  [ make ]
-]
-install: [ make "install" ]
-remove:  [ "ocamlfind" "remove" "nocrypto" ]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
+                "--tests" "false"
+                "--with-lwt" "%{lwt:installed}%"
+                "--xen" "%{mirage-xen:installed}%"
+                "--freestanding" "%{ocaml-freestanding:installed}%"]
 
 depends: [
   "ocamlfind" {build}
-  "ocamlbuild" {build}
-  "oasis" {build}
+  "ocamlbuild"
+  "topkg" {build}
   "ppx_sexp_conv" {build}
+  "cpuid" {build}
+  "ocb-stubblr" {build}
+  "ounit" {test}
   "cstruct" {>= "1.6.0"}
   "zarith"
   "sexplib"
-  ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy-xen" & "zarith-xen"))
-  ("mirage-no-solo5" | ("mirage-solo5" & "mirage-entropy-solo5" & "zarith-freestanding"))
-  "ounit" {test}
+  ("mirage-no-xen" | ("mirage-xen" & "mirage-entropy" & "zarith-xen"))
+  ("mirage-no-solo5" | ("mirage-solo5" & "mirage-entropy" & "zarith-freestanding"))
 ]
 
-depopts: [
-  "lwt"
-]
-
-conflicts: [
-  "mirage-xen" {<"2.2.0"}
-  "mirage-entropy-xen" {<"0.3.0"}
-]
-
-build-test: [
-  [ "./configure" "--%{ounit:enable}%-tests" ]
-  [ make "test" ]
-]
-
-tags: [ "org:mirage" ]
-available: [ ocaml-version >= "4.02.0" ]
+depopts: [ "lwt" ]

--- a/packages/nocrypto/nocrypto.dev~mirage/url
+++ b/packages/nocrypto/nocrypto.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/hannesm/ocaml-nocrypto.git#p"
+git: "git://github.com/mirleft/ocaml-nocrypto.git"

--- a/packages/ocb-stubblr/ocb-stubblr.dev~mirage/descr
+++ b/packages/ocb-stubblr/ocb-stubblr.dev~mirage/descr
@@ -1,0 +1,18 @@
+OCamlbuild plugin for C stubs
+
+Do you get excited by C stubs? Do they sometimes make you swoon, and even faint,
+and in the end no `cmxa`s get properly linked -- not to mention correct
+multi-lib support?
+
+Do you wish that the things that excite you the most, would excite you just a
+little less? Then ocb-stubblr is just the library for you.
+
+ocb-stubblr is about ten lines of code that you need to repeat over, over, over
+and over again if you are using `ocamlbuild` to build OCaml projects that
+contain C stubs -- now with 100% more lib!
+
+It does what everyone wants to do with `.clib` files in their project
+directories. It can also clone the `.clib` and arrange for multiple compilations
+with different sets of discovered `cflags`.
+
+ocb-stubblr is distributed under the ISC license.

--- a/packages/ocb-stubblr/ocb-stubblr.dev~mirage/opam
+++ b/packages/ocb-stubblr/ocb-stubblr.dev~mirage/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "David Kaloper Meršinjak <david@numm.org>"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/pqwy/ocb-stubblr"
+doc: "https://pqwy.github.io/ocb-stubblr/doc"
+license: "ISC"
+dev-repo: "https://github.com/pqwy/ocb-stubblr.git"
+bug-reports: "https://github.com/pqwy/ocb-stubblr/issues"
+tags: []
+available: [ ocaml-version >= "4.02.0"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild"
+  "topkg"
+  "astring" ]
+depopts: []
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]

--- a/packages/ocb-stubblr/ocb-stubblr.dev~mirage/url
+++ b/packages/ocb-stubblr/ocb-stubblr.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "git://github.com/pqwy/ocb-stubblr.git"


### PR DESCRIPTION
I was far, far too quick to release bits of this in the main repo, in hopes of avoiding dev pins for the supporting libs.

Turns out, the entire set of changes had variously wrong version constraints, and even some bad `META`s floating around. :sob: 

Versions in this PR should work well together.

Note that it introduces yet another entropy package, `mirage-entropy`. That one obsoletes `mirage-entropy-xen` and `mirage-entropy-solo5`. If, by coincidence, this PR turns out to work, various tests floating around must remove `mirage-entropy-xen` from the list of packages they install.