### PR TITLE
Don't test on 4.02 for the set of packages included in Mirage 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,3 @@ env:
     - OCAML_VERSION=4.03 MODE=xen
     - OCAML_VERSION=4.03 MODE=ukvm
     - OCAML_VERSION=4.03 MODE=virtio
-    - OCAML_VERSION=4.02 MODE=unix
-    - OCAML_VERSION=4.02 MODE=xen
-    - OCAML_VERSION=4.02 MODE=ukvm
-    - OCAML_VERSION=4.02 MODE=virtio


### PR DESCRIPTION
Once core dependencies (`ipaddr` and others which rely on `janestreet` libraries, at a minimum) are buildable on 4.04, we should begin testing that compiler instead.