### PR TITLE
hvsock: point at mirage/ocaml-hvsock rather than avsm/ocaml-hvsock

### DIFF
--- a/packages/hvsock/hvsock.dev~mirage/url
+++ b/packages/hvsock/hvsock.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "https://github.com/avsm/ocaml-hvsock.git#mirage-3.0"
+git: "https://github.com/mirage/ocaml-hvsock.git#mirage-3.0"


### PR DESCRIPTION
Related to [mirage/ocaml-hvsock#33]

Signed-off-by: David Scott <dave@recoil.org>