### PR TITLE
ocaml-freestanding: Sync OPAM (4.04 support)

### DIFF
--- a/packages/ocaml-freestanding/ocaml-freestanding.dev~mirage/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.dev~mirage/opam
@@ -19,5 +19,5 @@ depends: [
 ]
 
 available: [
-  ocaml-version >= "4.02.3" & ocaml-version <= "4.03.0" & (arch = "x86_64" | arch = "amd64")
+  ocaml-version >= "4.02.3" & ocaml-version <= "4.05.0" & (arch = "x86_64" | arch = "amd64")
 ]


### PR DESCRIPTION
@hannesm @yomimono This enables Solo5 targets on 4.04.0. We should probably add 4.04.0 to the various Travis builds, but I'll leave that to you (not sure what limitations on the # of builds we have).