### PR TITLE
Add mirage-clock-freestanding

### DIFF
--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.dev~mirage/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.dev~mirage/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+maintainer: "anil@recoil.org"
+homepage: "https://github.com/mirage/mirage-clock"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+license: "ISC"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mirage-types" {>= "0.3.0"}
+  "mirage-types-lwt"
+  "lwt"
+]
+build: [
+  "ocaml" "pkg/pkg.ml" "build"
+            "--pkg-name" name
+            "--pinned" "%{pinned}%" ]
+dev-repo: "git://github.com/mirage/mirage-clock"

--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.dev~mirage/url
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mirage/mirage-clock.git"


### PR DESCRIPTION
Depends on mirage/mirage-clock#21, mirage/mirage#684.

`mirage-clock-xen` will be removed in a separate PR once this goes in.