### PR TITLE
automatically add {>= 3.0.0} version constraints for mirage-types{-lwt}

### DIFF
--- a/packages/channel/channel.dev~mirage/opam
+++ b/packages/channel/channel.dev~mirage/opam
@@ -7,13 +7,13 @@ license: "ISC"
 dev-repo: "https://github.com/mirage/mirage-channel.git"
 bug-reports: "https://github.com/mirage/mirage-channel/issues"
 tags: ["org:mirage"]
-available: [ ocaml-version >= "4.01.0"]
+available: [ocaml-version >= "4.01.0"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
   "mirage-types" {>= "3.0.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "io-page"
   "lwt" {>= "2.4.7"}
   "cstruct"
@@ -22,7 +22,13 @@ depends: [
   "ounit" {test}
   "mirage-flow" {test}
 ]
-conflicts: [ "tcpip" {<"2.5.0"} ]
-depopts: []
-build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
-build-test: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
+conflicts: [
+  "tcpip" {< "2.5.0"}
+]
+
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+]
+build-test: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
+]

--- a/packages/datakit/datakit.dev~mirage/opam
+++ b/packages/datakit/datakit.dev~mirage/opam
@@ -1,45 +1,52 @@
 opam-version: "1.2"
-maintainer:   "thomas@gazagnaire.org"
-authors:      ["Thomas Leonard" "Magnus Skjegstad"
-               "David Scott" "Thomas Gazagnaire"]
-license:      "Apache"
-homepage:     "https://github.com/docker/datakit"
-bug-reports:  "https://github.com/docker/datakit/issues"
-dev-repo:     "https://github.com/docker/datakit.git"
-doc:          "https://docker.github.io/datakit/"
-
-build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"]
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Leonard" "Magnus Skjegstad" "David Scott" "Thomas Gazagnaire"
+]
+license: "Apache"
+homepage: "https://github.com/docker/datakit"
+bug-reports: "https://github.com/docker/datakit/issues"
+dev-repo: "https://github.com/docker/datakit.git"
+doc: "https://docker.github.io/datakit/"
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
+]
 build-test: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
   ["ocaml" "pkg/pkg.ml" "test"]
 ]
-
 depends: [
-  "ocamlfind"  {build}
+  "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg"      {build}
+  "topkg" {build}
   "datakit-server" {>= "0.7.0"}
   "cmdliner"
-  "rresult" "astring" "fmt" "asetmap"
-  "git"         {>= "1.9.3"}
-  "mirage-tc" "uri"
-  "mirage-types"
-  "irmin"       {>= "0.12.0"}
-  "camlzip"     {>= "1.06"}
-  "cstruct"     {>= "2.2"}
-  "result" "lwt"
-  "conduit" "mirage-flow"
+  "rresult"
+  "astring"
+  "fmt"
+  "asetmap"
+  "git" {>= "1.9.3"}
+  "mirage-tc"
+  "uri"
+  "mirage-types" {>= "3.0.0"}
+  "irmin" {>= "0.12.0"}
+  "camlzip" {>= "1.06"}
+  "cstruct" {>= "2.2"}
+  "result"
+  "lwt"
+  "conduit"
+  "mirage-flow"
   "cohttp"
-  "named-pipe"  {>= "0.4.0"}
-  "hvsock"      {>= "0.8.1"}
-  "logs"        {>= "0.5.0"}
+  "named-pipe" {>= "0.4.0"}
+  "hvsock" {>= "0.8.1"}
+  "logs" {>= "0.5.0"}
   "win-eventlog"
-  "asl"         {>= "0.10"}
+  "asl" {>= "0.10"}
   "mtime"
   "irmin-watcher" {>= "0.2.0"}
   "datakit-client" {test}
   "datakit-server"
   "datakit-github" {test}
-  "alcotest"       {test & >= "0.7.0"}
+  "alcotest" {test & >= "0.7.0"}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/git-mirage/git-mirage.dev~mirage/opam
+++ b/packages/git-mirage/git-mirage.dev~mirage/opam
@@ -1,15 +1,14 @@
 opam-version: "1.2"
-maintainer:   "thomas@gazagnaire.org"
-authors:      "Thomas Gazagnaire"
-license:      "ISC"
-homepage:     "https://github.com/mirage/ocaml-git"
-bug-reports:  "https://github.com/mirage/ocaml-git/issues"
-dev-repo:     "https://github.com/mirage/ocaml-git.git"
-
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+dev-repo: "https://github.com/mirage/ocaml-git.git"
 depends: [
   "mirage-http"
   "mirage-flow"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "channel"
   "git" {>= "1.6.0"}
 ]

--- a/packages/irmin-mirage/irmin-mirage.dev~mirage/opam
+++ b/packages/irmin-mirage/irmin-mirage.dev~mirage/opam
@@ -1,14 +1,13 @@
 opam-version: "1.2"
-maintainer:   "thomas@gazagnaire.org"
-authors:      "Thomas Gazagnaire"
-license:      "ISC"
-homepage:     "https://github.com/mirage/irmin"
-bug-reports:  "https://github.com/mirage/irmin/issues"
-dev-repo:     "https://github.com/mirage/irmin.git"
-
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+dev-repo: "https://github.com/mirage/irmin.git"
 depends: [
   "mirage-types" {>= "3.0.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "git-mirage"
   "irmin"
 ]

--- a/packages/mirage-block-ccm/mirage-block-ccm.dev~mirage/opam
+++ b/packages/mirage-block-ccm/mirage-block-ccm.dev~mirage/opam
@@ -1,32 +1,29 @@
 opam-version: "1.2"
-name:         "mirage-block-ccm"
-homepage:     "https://github.com/sg2342/mirage-block-ccm"
-dev-repo:     "https://github.com/sg2342/mirage-block-ccm.git"
-bug-reports:  "https://github.com/sg2342/mirage-block-ccm/issues"
-author:       ["Stefan Grundmann <sg2342@googlemail.com>"]
-maintainer:   ["Stefan Grundmann <sg2342@googlemail.com>"]
-license:      "ISC"
-
+name: "mirage-block-ccm"
+homepage: "https://github.com/sg2342/mirage-block-ccm"
+dev-repo: "https://github.com/sg2342/mirage-block-ccm.git"
+bug-reports: "https://github.com/sg2342/mirage-block-ccm/issues"
+author: ["Stefan Grundmann <sg2342@googlemail.com>"]
+maintainer: ["Stefan Grundmann <sg2342@googlemail.com>"]
+license: "ISC"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
-install: [ make "install" ]
+install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-block-ccm"]
-
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "mirage-types-lwt" 
+  "mirage-types-lwt" {>= "3.0.0"}
   "nocrypto" {>= "0.5.1"}
   "io-page" {>= "1.0.0"}
   "ounit" {test}
   "bisect" {test}
 ]
-
 build-test: [
-  [ "./configure" "--%{ounit:enable}%-tests" "--%{bisect:enable}%-coverage" ]
-  [ make "cover_test" ] ]
-
+  ["./configure" "--%{ounit:enable}%-tests" "--%{bisect:enable}%-coverage"]
+  [make "cover_test"]
+]
 available: [ocaml-version > "4.02.0"]

--- a/packages/mirage-block-ramdisk/mirage-block-ramdisk.dev~mirage/opam
+++ b/packages/mirage-block-ramdisk/mirage-block-ramdisk.dev~mirage/opam
@@ -2,22 +2,18 @@ opam-version: "1.2"
 name: "mirage-block-ramdisk"
 maintainer: "dave@recoil.org"
 version: "0.1"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/mirage-block-ramdisk"
 dev-repo: "https://github.com/mirage/mirage-block-ramdisk.git"
 bug-reports: "https://github.com/mirage/mirage-block-ramdisk/issues"
-
-tags: [
-  "org:mirage"
-]
+tags: ["org:mirage"]
 build: ["ocaml" "pkg/pkg.ml" "build"]
-
 depends: [
   "base-bytes"
   "cstruct"
   "io-page"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "lwt"
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/mirage-block/mirage-block.dev~mirage/opam
+++ b/packages/mirage-block/mirage-block.dev~mirage/opam
@@ -2,27 +2,23 @@ opam-version: "1.2"
 name: "mirage-block"
 maintainer: "dave@recoil.org"
 version: "0.1"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/mirage-block"
 dev-repo: "https://github.com/mirage/mirage-block.git"
 bug-reports: "https://github.com/mirage/mirage-block/issues"
 
-tags: [
-]
-
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [["ocamlfind" "remove" "mirage-block"]]
-
+remove: [
+  ["ocamlfind" "remove" "mirage-block"]
+]
 depends: [
   "base-bytes"
   "cstruct"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "lwt"
   "logs"
   "ocamlfind" {build}
@@ -31,11 +27,9 @@ depends: [
   "mirage-block-ramdisk" {test}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
-
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-
 available: [ocaml-version >= "4.02.0"]

--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.dev~mirage/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.dev~mirage/opam
@@ -4,20 +4,16 @@ maintainer: "anil@recoil.org"
 homepage: "https://github.com/mirage/mirage-clock"
 bug-reports: "https://github.com/mirage/mirage-clock/issues"
 license: "ISC"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
   "mirage-types" {>= "0.3.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "lwt"
 ]
 build: [
-  "ocaml" "pkg/pkg.ml" "build"
-            "--pkg-name" name
-            "--pinned" "%{pinned}%" ]
+  "ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"
+]
 dev-repo: "git://github.com/mirage/mirage-clock"

--- a/packages/mirage-clock-unix/mirage-clock-unix.dev~mirage/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.dev~mirage/opam
@@ -4,21 +4,30 @@ maintainer: "anil@recoil.org"
 homepage: "https://github.com/mirage/mirage-clock"
 bug-reports: "https://github.com/mirage/mirage-clock/issues"
 license: "ISC"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
   "mirage-types" {>= "3.0.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "lwt"
 ]
-build: [ "ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" ]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"
+]
 build-test: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" "--tests" "true" ]
-  [ "ocaml" "pkg/pkg.ml" "test" ]
+  [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--pkg-name"
+    name
+    "--pinned"
+    "%{pinned}%"
+    "--tests"
+    "true"
+  ]
+  ["ocaml" "pkg/pkg.ml" "test"]
 ]
 dev-repo: "git://github.com/mirage/mirage-clock"

--- a/packages/mirage-console-solo5/mirage-console-solo5.dev~mirage/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.dev~mirage/opam
@@ -1,17 +1,15 @@
 opam-version: "1.2"
-maintainer:    "martin@lucina.net"
-homepage:      "https://github.com/mirage/mirage-console-solo5"
-bug-reports:   "https://github.com/mirage/mirage-console-solo5/issues"
-dev-repo:      "https://github.com/mirage/mirage-console-solo5.git"
-license:       "ISC"
+maintainer: "martin@lucina.net"
+homepage: "https://github.com/mirage/mirage-console-solo5"
+bug-reports: "https://github.com/mirage/mirage-console-solo5/issues"
+dev-repo: "https://github.com/mirage/mirage-console-solo5.git"
+license: "ISC"
 authors: [
   "Anil Madhavapeddy <anil@recoil.org>"
   "Dan Williams <djwillia@us.ibm.com>"
   "Martin Lucina <martin@lucina.net>"
 ]
-tags: [
-  "org:mirage"
-]
+tags: ["org:mirage"]
 build: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 ]
@@ -19,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "mirage-solo5"
   "mirage-runtime"
   "cstruct"

--- a/packages/mirage-console-xen/mirage-console-xen.dev~mirage/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.dev~mirage/opam
@@ -1,21 +1,23 @@
 opam-version: "1.2"
-maintainer:    "anil@recoil.org"
-homepage:      "https://github.com/mirage/mirage-console"
-bug-reports:   "https://github.com/mirage/mirage-console/issues"
-dev-repo:      "https://github.com/mirage/mirage-console.git"
-doc:           "https://mirage.github.io/mirage-console/"
-authors:       [ "Anil Madhavapeddy" "David Scott"]
-tags:          [ "org:mirage" "org:xapi-project"]
-license:       "ISC"
-
-build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
-
+maintainer: "anil@recoil.org"
+homepage: "https://github.com/mirage/mirage-console"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+dev-repo: "https://github.com/mirage/mirage-console.git"
+doc: "https://mirage.github.io/mirage-console/"
+authors: ["Anil Madhavapeddy" "David Scott"]
+tags: ["org:mirage" "org:xapi-project"]
+license: "ISC"
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"
+]
 depends: [
-  "ocamlfind"  {build}
+  "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg"      {build & >= "0.7.3"}
+  "topkg" {build & >= "0.7.3"}
   "mirage-console-xen-proto"
-  "mirage-types-lwt"
-  "xen-evtchn" "xen-gnt" "mirage-xen"
+  "mirage-types-lwt" {>= "3.0.0"}
+  "xen-evtchn"
+  "xen-gnt"
+  "mirage-xen"
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/mirage-flow/mirage-flow.dev~mirage/opam
+++ b/packages/mirage-flow/mirage-flow.dev~mirage/opam
@@ -1,6 +1,8 @@
 opam-version: "1.2"
 maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
-authors: [ "Thomas Gazagnaire <thomas@gazagnaire.org>" "David Scott <dave@recoil.org>" ]
+authors: [
+  "Thomas Gazagnaire <thomas@gazagnaire.org>" "David Scott <dave@recoil.org>"
+]
 homepage: "https://github.com/mirage/mirage-flow"
 bug-reports: "https://github.com/mirage/mirage-flow/issues/"
 license: "ISC"
@@ -17,11 +19,11 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-flow"]
 depends: [
   "ocamlbuild" {build}
-  "ocamlfind"  {build}
+  "ocamlfind" {build}
   "mirage-types" {>= "3.0.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "cstruct"
   "lwt" {>= "2.5.0"}
   "alcotest" {test}
-  "ounit"    {test}
+  "ounit" {test}
 ]

--- a/packages/mirage-http/mirage-http.dev~mirage/opam
+++ b/packages/mirage-http/mirage-http.dev~mirage/opam
@@ -1,19 +1,17 @@
 opam-version: "1.2"
-maintainer:   "anil@recoil.org"
-authors:      ["Anil Madhavapeddy" "Thomas Gazagnaire"]
-homepage:     "https://github.com/mirage/mirage-http"
-bug-reports:  "https://github.com/mirage/mirage-http/issues/"
-dev-repo:     "https://github.com/mirage/mirage-http.git"
-doc:          "https://mirage.github.io/mirage-http/"
-
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+homepage: "https://github.com/mirage/mirage-http"
+bug-reports: "https://github.com/mirage/mirage-http/issues/"
+dev-repo: "https://github.com/mirage/mirage-http.git"
+doc: "https://mirage.github.io/mirage-http/"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
-
 depends: [
-  "ocamlfind"  {build}
+  "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg"      {build}
+  "topkg" {build}
   "mirage-types" {>= "2.0.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "conduit"
   "mirage-conduit" {>= "2.2.0"}
   "lwt" {>= "2.4.3"}

--- a/packages/mirage-net-macosx/mirage-net-macosx.dev~mirage/opam
+++ b/packages/mirage-net-macosx/mirage-net-macosx.dev~mirage/opam
@@ -1,24 +1,21 @@
 opam-version: "1.2"
-
-maintainer:  "Anil Madhavapeddy <anil@recoil.org>"
-authors:     "Anil Madhavapeddy <anil@recoil.org>"
-homepage:    "https://github.com/mirage/mirage-net-macosx"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+homepage: "https://github.com/mirage/mirage-net-macosx"
 bug-reports: "https://github.com/mirage/mirage-net-macosx/issues"
-dev-repo:    "https://github.com/mirage/mirage-net-macosx.git"
-doc:         "https://mirage.github.io/mirage-net-macosx/"
-
+dev-repo: "https://github.com/mirage/mirage-net-macosx.git"
+doc: "https://mirage.github.io/mirage-net-macosx/"
 license: "ISC"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
-
 depends: [
   "ocamlfind" {build}
-  "topkg"     {build}
+  "topkg" {build}
   "cstruct" {>= "1.4.0"}
   "ipaddr"
   "sexplib"
   "lwt" {>= "2.4.3"}
-  "mirage-types"
-  "mirage-types-lwt"
+  "mirage-types" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0"}
   "io-page" {>= "1.4.0"}
   "vmnet"
 ]

--- a/packages/mirage-net-solo5/mirage-net-solo5.dev~mirage/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.dev~mirage/opam
@@ -1,10 +1,14 @@
 opam-version: "1.2"
-maintainer:    "martin@lucina.net"
-homepage:      "https://github.com/mirage/mirage-net-solo5"
-bug-reports:   "https://github.com/mirage/mirage-net-solo5/issues"
-dev-repo:      "https://github.com/mirage/mirage-net-solo5.git"
-authors:       [ "Anil Madhavapeddy <anil@recoil.org>" "Dan Williams <djwillia@us.ibm.com>" "Martin Lucina <martin@lucina.net>" ]
-license:       "ISC"
+maintainer: "martin@lucina.net"
+homepage: "https://github.com/mirage/mirage-net-solo5"
+bug-reports: "https://github.com/mirage/mirage-net-solo5/issues"
+dev-repo: "https://github.com/mirage/mirage-net-solo5.git"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+license: "ISC"
 build: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 ]
@@ -14,10 +18,10 @@ depends: [
   "topkg" {build}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "io-page" {>= "1.0.0"}
   "ipaddr" {>= "1.0.0"}
   "mirage-solo5"
   "logs" {>= "0.6.0"}
 ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ocaml-version >= "4.01.0"]

--- a/packages/mirage-qubes/mirage-qubes.dev~mirage/opam
+++ b/packages/mirage-qubes/mirage-qubes.dev~mirage/opam
@@ -1,30 +1,33 @@
 opam-version: "1.2"
-maintainer:   "talex@gmail.com"
-authors:      ["Thomas Leonard"]
-license:      "BSD-2-Clause"
-homepage:     "https://github.com/talex5/mirage-qubes"
-bug-reports:  "https://github.com/talex5/mirage-qubes/issues"
-dev-repo:     "https://github.com/talex5/mirage-qubes.git"
-
-build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
-        "--with-ipv4" "%{tcpip+ipaddr:installed}%"
+maintainer: "talex@gmail.com"
+authors: ["Thomas Leonard"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/talex5/mirage-qubes"
+bug-reports: "https://github.com/talex5/mirage-qubes/issues"
+dev-repo: "https://github.com/talex5/mirage-qubes.git"
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--pinned"
+  "%{pinned}%"
+  "--tests"
+  "false"
+  "--with-ipv4"
+  "%{tcpip+ipaddr:installed}%"
 ]
-
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "cstruct" { >= "1.9.0" }
-  "vchan" { >= "2.0.0" }
+  "cstruct" {>= "1.9.0"}
+  "vchan" {>= "2.0.0"}
   "xen-evtchn"
   "xen-gnt"
   "mirage-xen"
   "lwt"
-  "mirage-types"
-  "logs" { >= "0.5.0" }
+  "mirage-types" {>= "3.0.0"}
+  "logs" {>= "0.5.0"}
 ]
-depopts: [
-  "ipaddr"
-  "tcpip"
-]
+depopts: ["ipaddr" "tcpip"]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/mirage-runtime/mirage-runtime.dev~mirage/opam
+++ b/packages/mirage-runtime/mirage-runtime.dev~mirage/opam
@@ -1,24 +1,33 @@
 opam-version: "1.2"
-maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
-authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
-               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
-               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
-homepage:     "https://mirage.io/"
-bug-reports:  "https://github.com/mirage/mirage/issues/"
-dev-repo:     "https://github.com/mirage/mirage.git"
-tags:         ["org:mirage" "org:xapi-project"]
-doc:          "https://mirage.github.io/mirage/"
-
-build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
-
+maintainer: ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+homepage: "https://mirage.io/"
+bug-reports: "https://github.com/mirage/mirage/issues/"
+dev-repo: "https://github.com/mirage/mirage.git"
+tags: ["org:mirage" "org:xapi-project"]
+doc: "https://mirage.github.io/mirage/"
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"
+]
 depends: [
   "ocamlbuild" {build}
-  "ocamlfind"  {build}
-  "topkg"      {build & >= "0.8.0"}
-  "ipaddr"             {>= "2.6.0"}
+  "ocamlfind" {build}
+  "topkg" {build & >= "0.8.0"}
+  "ipaddr" {>= "2.6.0"}
   "functoria-runtime"
   "astring"
   "logs"
-  "mirage-types"
+  "mirage-types" {>= "3.0.0"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/mirage-stdlib-random/mirage-stdlib-random.dev~mirage/opam
+++ b/packages/mirage-stdlib-random/mirage-stdlib-random.dev~mirage/opam
@@ -6,15 +6,13 @@ doc: "https://hannesm.github.io/mirage-stdlib-random/doc"
 dev-repo: "https://github.com/hannesm/mirage-stdlib-random.git"
 bug-reports: "https://github.com/hannesm/mirage-stdlib-random/issues"
 license: "ISC"
-
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "cstruct" {>= "1.9.0"}
 ]
-
 build: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 ]

--- a/packages/protocol-9p/protocol-9p.dev~mirage/opam
+++ b/packages/protocol-9p/protocol-9p.dev~mirage/opam
@@ -1,28 +1,39 @@
 opam-version: "1.2"
-maintainer:   "dave@recoil.org"
-authors:      [ "David Scott" "David Sheets" "Thomas Leonard" ]
-license:      "ISC"
-homepage:     "https://github.com/mirage/ocaml-9p"
-dev-repo:     "https://github.com/mirage/ocaml-9p.git"
-bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
-doc:          "https://mirage.github.io/ocaml-9p/"
-
-build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "true"
-          "--with-lambda-term" lambda-term:installed]
-
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "David Sheets" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-9p"
+dev-repo: "https://github.com/mirage/ocaml-9p.git"
+bug-reports: "https://github.com/mirage/ocaml-9p/issues"
+doc: "https://mirage.github.io/ocaml-9p/"
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--pinned"
+  "true"
+  "--with-lambda-term"
+  lambda-term:installed
+]
 build-test: [
-  ["ocaml" "pkg/pkg.ml" "build" "--tests" "true"
-     "--with-lambda-term" lambda-term:installed]
+  [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--tests"
+    "true"
+    "--with-lambda-term"
+    lambda-term:installed
+  ]
   ["ocaml" "pkg/pkg.ml" "test"]
 ]
-
 depends: [
   "base-bytes"
   "cstruct" {>= "1.9.0"}
-  "sexplib" {> "113.00.00" }
+  "sexplib" {> "113.00.00"}
   "result"
-  "mirage-types-lwt"
-  "channel" {>= "1.1.0" }
+  "mirage-types-lwt" {>= "3.0.0"}
+  "channel" {>= "1.1.0"}
   "lwt" {>= "2.4.7"}
   "base-unix"
   "cmdliner"

--- a/packages/qcow-format/qcow-format.dev~mirage/opam
+++ b/packages/qcow-format/qcow-format.dev~mirage/opam
@@ -1,32 +1,27 @@
 opam-version: "1.2"
 name: "qcow-format"
 maintainer: "dave@recoil.org"
-authors: [ "David Scott" ]
+authors: ["David Scott"]
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-qcow"
 dev-repo: "https://github.com/mirage/ocaml-qcow.git"
 bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
-
-tags: [
-  "org:mirage"
-]
-
+tags: ["org:mirage"]
 build: [
   [make "PREFIX=%{prefix}%"]
 ]
-
 install: [make "PREFIX=%{prefix}%" "install"]
-
-remove: [[make "PREFIX=%{prefix}%" "uninstall"]]
-
+remove: [
+  [make "PREFIX=%{prefix}%" "uninstall"]
+]
 depends: [
   "base-bytes"
   "cstruct"
   "result"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "lwt"
-  "mirage-block" {>= "0.2" }
-  "mirage-block-unix" {>= "2.1.0" }
+  "mirage-block" {>= "0.2"}
+  "mirage-block-unix" {>= "2.1.0"}
   "cmdliner"
   "sexplib"
   "logs"
@@ -43,11 +38,9 @@ depends: [
   "nbd" {test & >= "2.0.1"}
 ]
 build-doc: ["ocaml" "setup.ml" "-doc"]
-
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--enable-tests"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test"]
 ]
-
 available: [ocaml-version >= "4.02.0"]

--- a/packages/shared-block-ring/shared-block-ring.dev~mirage/opam
+++ b/packages/shared-block-ring/shared-block-ring.dev~mirage/opam
@@ -1,19 +1,18 @@
 opam-version: "1.2"
 maintainer: "jonathan.ludlam@citrix.com"
-authors: [ "David Scott" "Jon Ludlam" "Si Beaumont" ]
+authors: ["David Scott" "Jon Ludlam" "Si Beaumont"]
 homepage: "https://github.com/mirage/shared-block-ring"
 bug-reports: "https://github.com/mirage/shared-block-ring/issues/"
 dev-repo: "https://github.com/mirage/shared-block-ring.git"
 license: "ISC"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
+tags: ["org:mirage" "org:xapi-project"]
 build: [
   [make "all"]
 ]
 install: [make "install"]
-remove: [["ocamlfind" "remove" "shared-block-ring"]]
+remove: [
+  ["ocamlfind" "remove" "shared-block-ring"]
+]
 depends: [
   "cstruct" {>= "0.7.1"}
   "ppx_tools" {build}
@@ -21,7 +20,7 @@ depends: [
   "lwt"
   "ocamlfind"
   "ounit"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "mirage-block-unix"
   "mirage-clock-unix"
   "sexplib"

--- a/packages/vchan/vchan.dev~mirage/opam
+++ b/packages/vchan/vchan.dev~mirage/opam
@@ -1,16 +1,16 @@
 opam-version: "1.2"
-maintainer:    "jonathan.ludlam@eu.citrix.com"
-authors: [
-  "Vincent Bernardoff"
-  "Jon Ludlam"
-]
-homepage:    "http://github.com/mirage/ocaml-vchan"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam"]
+homepage: "http://github.com/mirage/ocaml-vchan"
 bug-reports: "http://github.com/mirage/ocaml-vchan/issues"
-dev-repo:    "http://github.com/mirage/ocaml-vchan.git"
-license:     "ISC"
-
+dev-repo: "http://github.com/mirage/ocaml-vchan.git"
+license: "ISC"
 build: [
-  ["./configure" "--%{xen-evtchn+xen-gnt:enable}%-xenctrl" "--%{mirage-xen:enable}%-xen"]
+  [
+    "./configure"
+    "--%{xen-evtchn+xen-gnt:enable}%-xenctrl"
+    "--%{mirage-xen:enable}%-xen"
+  ]
   [make "build"]
 ]
 build-test: [make "test"]
@@ -22,14 +22,13 @@ remove: [
   [make "js-uninstall"]
   ["ocamlfind" "remove" "vchan"]
 ]
-
 depends: [
   "ocamlfind" {build}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
   "io-page"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "xenstore" {>= "1.2.2"}
   "xenstore_transport"
   "sexplib"
@@ -37,16 +36,12 @@ depends: [
   "result"
   "ounit" {test}
 ]
-depopts: [
-  "xen-evtchn"
-  "xen-gnt"
-  "mirage-xen"
-]
+depopts: ["xen-evtchn" "xen-gnt" "mirage-xen"]
 conflicts: [
- "xen-evtchn" {< "1.0.3"}
- ]
+  "xen-evtchn" {< "1.0.3"}
+]
 available: [ocaml-version >= "4.02.0"]
 depexts: [
- [["debian"] ["libxen-dev" "uuid-dev"]]
- [["ubuntu"] ["libxen-dev" "uuid-dev"]]
+  [["debian"] ["libxen-dev" "uuid-dev"]]
+  [["ubuntu"] ["libxen-dev" "uuid-dev"]]
 ]

--- a/packages/vhd-format/vhd-format.dev~mirage/opam
+++ b/packages/vhd-format/vhd-format.dev~mirage/opam
@@ -1,20 +1,19 @@
 opam-version: "1.2"
 maintainer: "dave@recoil.org"
-tags: [
-  "org:mirage"
-  "org:xapi-project"
-]
-authors: [ "Dave Scott" "Jon Ludlam" ]
+tags: ["org:mirage" "org:xapi-project"]
+authors: ["Dave Scott" "Jon Ludlam"]
 homepage: "https://github.com/mirage/ocaml-vhd"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 dev-repo: "git://github.com/mirage/ocaml-vhd"
 build: make
-remove: [[make "uninstall"]]
+remove: [
+  [make "uninstall"]
+]
 depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "ipaddr"
   "io-page"
   "uuidm"
@@ -23,7 +22,7 @@ depends: [
   "ocamlbuild" {build}
 ]
 depexts: [
- [["alpine"]["linux-headers"]]
+  [["alpine"] ["linux-headers"]]
 ]
-available: [ (os = "linux" | os = "darwin") & ocaml-version >= "4.02.3" ]
+available: [(os = "linux" | os = "darwin") & ocaml-version >= "4.02.3"]
 install: [make "install"]


### PR DESCRIPTION
All affected files have had a run through an automated parser/printer and no attempt has been made to preserve whitespace.