### PR TITLE
conduit conflicts w/mirage-types < 3

### DIFF
--- a/packages/conduit/conduit.dev~mirage/opam
+++ b/packages/conduit/conduit.dev~mirage/opam
@@ -39,7 +39,7 @@ conflicts: [
   "lwt" {<"2.4.4"}
   "async_ssl" {<"112.24.00"}
   "async" {<"113.24.00"}
-  "mirage-types" {<"2.0.0"}
+  "mirage-types" {<"3.0.0"}
   "dns" {<"0.10.0"}
   "tls" {<"0.4.0"}
   "vchan" {<"2.0.0"}


### PR DESCRIPTION
conflicts with version less than x are commonly really depopt version dependencies; these should be automatically updated too, but in the meantime here's one I noticed.