### PR TITLE
automatically add {>= 3.0.0} version constraints for mirage-types{-lwt}

### DIFF
--- a/packages/channel/channel.dev~mirage/opam
+++ b/packages/channel/channel.dev~mirage/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "mirage-types" {>= "3.0.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "io-page"
   "lwt" {>= "2.4.7"}
   "cstruct"
@@ -23,6 +23,5 @@ depends: [
   "mirage-flow" {test}
 ]
 conflicts: [ "tcpip" {<"2.5.0"} ]
-depopts: []
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
 build-test: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]

--- a/packages/crunch/crunch.dev~mirage/opam
+++ b/packages/crunch/crunch.dev~mirage/opam
@@ -15,11 +15,10 @@ depends: [
   "bos" {test}
   "cstruct" {test}
   "lwt" {test}
-  "mirage-types" {test}
-  "mirage-types-lwt" {test}
+  "mirage-types" {test & >= "3.0.0"}
+  "mirage-types-lwt" {test & >= "3.0.0"}
   "io-page" {test}
 ]
-
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
 build-test: [
   [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]

--- a/packages/datakit/datakit.dev~mirage/opam
+++ b/packages/datakit/datakit.dev~mirage/opam
@@ -15,31 +15,37 @@ build-test: [
 ]
 
 depends: [
-  "ocamlfind"  {build}
+  "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg"      {build}
+  "topkg" {build}
   "datakit-server" {>= "0.7.0"}
   "cmdliner"
-  "rresult" "astring" "fmt" "asetmap"
-  "git"         {>= "1.9.3"}
-  "mirage-tc" "uri"
-  "mirage-types"
-  "irmin"       {>= "0.12.0"}
-  "camlzip"     {>= "1.06"}
-  "cstruct"     {>= "2.2"}
-  "result" "lwt"
-  "conduit" "mirage-flow"
+  "rresult"
+  "astring"
+  "fmt"
+  "asetmap"
+  "git" {>= "1.9.3"}
+  "mirage-tc"
+  "uri"
+  "mirage-types" {>= "3.0.0"}
+  "irmin" {>= "0.12.0"}
+  "camlzip" {>= "1.06"}
+  "cstruct" {>= "2.2"}
+  "result"
+  "lwt"
+  "conduit"
+  "mirage-flow"
   "cohttp"
-  "named-pipe"  {>= "0.4.0"}
-  "hvsock"      {>= "0.8.1"}
-  "logs"        {>= "0.5.0"}
+  "named-pipe" {>= "0.4.0"}
+  "hvsock" {>= "0.8.1"}
+  "logs" {>= "0.5.0"}
   "win-eventlog"
-  "asl"         {>= "0.10"}
+  "asl" {>= "0.10"}
   "mtime"
   "irmin-watcher" {>= "0.2.0"}
   "datakit-client" {test}
   "datakit-server"
   "datakit-github" {test}
-  "alcotest"       {test & >= "0.7.0"}
+  "alcotest" {test & >= "0.7.0"}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/packages/git-mirage/git-mirage.dev~mirage/opam
+++ b/packages/git-mirage/git-mirage.dev~mirage/opam
@@ -9,7 +9,7 @@ dev-repo:     "https://github.com/mirage/ocaml-git.git"
 depends: [
   "mirage-http"
   "mirage-flow"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "channel"
   "git" {>= "1.6.0"}
 ]

--- a/packages/git/git.dev~mirage/opam
+++ b/packages/git/git.dev~mirage/opam
@@ -23,27 +23,27 @@ build-test: [
 
 depends: [
   "cmdliner"
-  "mstruct"    {>= "1.3.1"}
+  "mstruct" {>= "1.3.1"}
   "ocamlgraph"
-  "uri"        {>= "1.3.12"}
-  "lwt"        {>= "2.4.7"}
+  "uri" {>= "1.3.12"}
+  "lwt" {>= "2.4.7"}
   "mtime"
   "logs"
   "fmt"
   "hex"
   "astring"
   "crc"
-  "alcotest"         {test}
-  "mirage-types-lwt" {test}
-  "mirage-http"      {test}
-  "mirage-flow"      {test}
-  "channel"          {test}
-  "mirage-fs-unix"   {test & >="1.1.4"}
-  "cohttp"           {test}
-  "conduit"          {test}
-  "base-unix"        {test}
-  "camlzip"          {test & >= "1.06"}
-  "nocrypto"         {test}
+  "alcotest" {test}
+  "mirage-types-lwt" {test & >= "3.0.0"}
+  "mirage-http" {test}
+  "mirage-flow" {test}
+  "channel" {test}
+  "mirage-fs-unix" {test & >= "1.1.4"}
+  "cohttp" {test}
+  "conduit" {test}
+  "base-unix" {test}
+  "camlzip" {test & >= "1.06"}
+  "nocrypto" {test}
 ]
 depopts: [
   # --enable-mirage

--- a/packages/irmin-mirage/irmin-mirage.dev~mirage/opam
+++ b/packages/irmin-mirage/irmin-mirage.dev~mirage/opam
@@ -8,7 +8,7 @@ dev-repo:     "https://github.com/mirage/irmin.git"
 
 depends: [
   "mirage-types" {>= "3.0.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "git-mirage"
   "irmin"
 ]

--- a/packages/mirage-block-ccm/mirage-block-ccm.dev~mirage/opam
+++ b/packages/mirage-block-ccm/mirage-block-ccm.dev~mirage/opam
@@ -3,7 +3,6 @@ name:         "mirage-block-ccm"
 homepage:     "https://github.com/sg2342/mirage-block-ccm"
 dev-repo:     "https://github.com/sg2342/mirage-block-ccm.git"
 bug-reports:  "https://github.com/sg2342/mirage-block-ccm/issues"
-author:       ["Stefan Grundmann <sg2342@googlemail.com>"]
 maintainer:   ["Stefan Grundmann <sg2342@googlemail.com>"]
 license:      "ISC"
 
@@ -18,15 +17,15 @@ depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "mirage-types-lwt" 
+  "mirage-types-lwt" {>= "3.0.0"}
   "nocrypto" {>= "0.5.1"}
   "io-page" {>= "1.0.0"}
   "ounit" {test}
   "bisect" {test}
 ]
-
 build-test: [
   [ "./configure" "--%{ounit:enable}%-tests" "--%{bisect:enable}%-coverage" ]
   [ make "cover_test" ] ]
 
 available: [ocaml-version > "4.02.0"]
+authors: "Stefan Grundmann <sg2342@googlemail.com>"

--- a/packages/mirage-block-ramdisk/mirage-block-ramdisk.dev~mirage/opam
+++ b/packages/mirage-block-ramdisk/mirage-block-ramdisk.dev~mirage/opam
@@ -1,7 +1,6 @@
 opam-version: "1.2"
 name: "mirage-block-ramdisk"
 maintainer: "dave@recoil.org"
-version: "0.1"
 authors: [ "David Scott" ]
 license: "ISC"
 homepage: "https://github.com/mirage/mirage-block-ramdisk"
@@ -17,7 +16,7 @@ depends: [
   "base-bytes"
   "cstruct"
   "io-page"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "lwt"
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/mirage-block/mirage-block.dev~mirage/opam
+++ b/packages/mirage-block/mirage-block.dev~mirage/opam
@@ -1,15 +1,11 @@
 opam-version: "1.2"
 name: "mirage-block"
 maintainer: "dave@recoil.org"
-version: "0.1"
 authors: [ "David Scott" ]
 license: "ISC"
 homepage: "https://github.com/mirage/mirage-block"
 dev-repo: "https://github.com/mirage/mirage-block.git"
 bug-reports: "https://github.com/mirage/mirage-block/issues"
-
-tags: [
-]
 
 build: [
   [make "PREFIX=%{prefix}%"]
@@ -22,7 +18,7 @@ remove: [["ocamlfind" "remove" "mirage-block"]]
 depends: [
   "base-bytes"
   "cstruct"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "lwt"
   "logs"
   "ocamlfind" {build}

--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.dev~mirage/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.dev~mirage/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "mirage-types" {>= "0.3.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "lwt"
 ]
 build: [

--- a/packages/mirage-clock-unix/mirage-clock-unix.dev~mirage/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.dev~mirage/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "mirage-types" {>= "3.0.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "lwt"
 ]
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" ]

--- a/packages/mirage-console-solo5/mirage-console-solo5.dev~mirage/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.dev~mirage/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "mirage-solo5"
   "mirage-runtime"
   "cstruct"

--- a/packages/mirage-console-xen/mirage-console-xen.dev~mirage/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.dev~mirage/opam
@@ -11,11 +11,13 @@ license:       "ISC"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 
 depends: [
-  "ocamlfind"  {build}
+  "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg"      {build & >= "0.7.3"}
+  "topkg" {build & >= "0.7.3"}
   "mirage-console-xen-proto"
-  "mirage-types-lwt"
-  "xen-evtchn" "xen-gnt" "mirage-xen"
+  "mirage-types-lwt" {>= "3.0.0"}
+  "xen-evtchn"
+  "xen-gnt"
+  "mirage-xen"
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/mirage-flow/mirage-flow.dev~mirage/opam
+++ b/packages/mirage-flow/mirage-flow.dev~mirage/opam
@@ -17,11 +17,11 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-flow"]
 depends: [
   "ocamlbuild" {build}
-  "ocamlfind"  {build}
+  "ocamlfind" {build}
   "mirage-types" {>= "3.0.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "cstruct"
   "lwt" {>= "2.5.0"}
   "alcotest" {test}
-  "ounit"    {test}
+  "ounit" {test}
 ]

--- a/packages/mirage-fs-unix/mirage-fs-unix.dev~mirage/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.dev~mirage/opam
@@ -17,13 +17,13 @@ depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.4.0"}
   "mirage-types" {>= "3.0.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "mirage-runtime"
   "lwt"
-  "rresult"           {test}
+  "rresult" {test}
   "mirage-clock-unix" {test}
-  "alcotest"          {test & >= "0.7.1"}
-  "ounit"             {test}
-  "ptime"             {test}
+  "alcotest" {test & >= "0.7.1"}
+  "ounit" {test}
+  "ptime" {test}
 ]
 available: [ ocaml-version >= "4.03.0"]

--- a/packages/mirage-net-macosx/mirage-net-macosx.dev~mirage/opam
+++ b/packages/mirage-net-macosx/mirage-net-macosx.dev~mirage/opam
@@ -12,13 +12,13 @@ build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 
 depends: [
   "ocamlfind" {build}
-  "topkg"     {build}
+  "topkg" {build}
   "cstruct" {>= "1.4.0"}
   "ipaddr"
   "sexplib"
   "lwt" {>= "2.4.3"}
-  "mirage-types"
-  "mirage-types-lwt"
+  "mirage-types" {>= "3.0.0"}
+  "mirage-types-lwt" {>= "3.0.0"}
   "io-page" {>= "1.4.0"}
   "vmnet"
 ]

--- a/packages/mirage-net-solo5/mirage-net-solo5.dev~mirage/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.dev~mirage/opam
@@ -14,7 +14,7 @@ depends: [
   "topkg" {build}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "io-page" {>= "1.0.0"}
   "ipaddr" {>= "1.0.0"}
   "mirage-solo5"

--- a/packages/mirage-qubes/mirage-qubes.dev~mirage/opam
+++ b/packages/mirage-qubes/mirage-qubes.dev~mirage/opam
@@ -14,14 +14,14 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "cstruct" { >= "1.9.0" }
-  "vchan" { >= "2.0.0" }
+  "cstruct" {>= "1.9.0"}
+  "vchan" {>= "2.0.0"}
   "xen-evtchn"
   "xen-gnt"
   "mirage-xen"
   "lwt"
-  "mirage-types"
-  "logs" { >= "0.5.0" }
+  "mirage-types" {>= "3.0.0"}
+  "logs" {>= "0.5.0"}
 ]
 depopts: [
   "ipaddr"

--- a/packages/mirage-runtime/mirage-runtime.dev~mirage/opam
+++ b/packages/mirage-runtime/mirage-runtime.dev~mirage/opam
@@ -19,6 +19,6 @@ depends: [
   "functoria-runtime"
   "astring"
   "logs"
-  "mirage-types"
+  "mirage-types" {>= "3.0.0"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/mirage-stdlib-random/mirage-stdlib-random.dev~mirage/opam
+++ b/packages/mirage-stdlib-random/mirage-stdlib-random.dev~mirage/opam
@@ -11,10 +11,9 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "cstruct" {>= "1.9.0"}
 ]
-
 build: [
   [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
 ]

--- a/packages/protocol-9p/protocol-9p.dev~mirage/opam
+++ b/packages/protocol-9p/protocol-9p.dev~mirage/opam
@@ -19,10 +19,10 @@ build-test: [
 depends: [
   "base-bytes"
   "cstruct" {>= "1.9.0"}
-  "sexplib" {> "113.00.00" }
+  "sexplib" {> "113.00.00"}
   "result"
-  "mirage-types-lwt"
-  "channel" {>= "1.1.0" }
+  "mirage-types-lwt" {>= "3.0.0"}
+  "channel" {>= "1.1.0"}
   "lwt" {>= "2.4.7"}
   "base-unix"
   "cmdliner"

--- a/packages/qcow-format/qcow-format.dev~mirage/opam
+++ b/packages/qcow-format/qcow-format.dev~mirage/opam
@@ -23,10 +23,10 @@ depends: [
   "base-bytes"
   "cstruct"
   "result"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "lwt"
-  "mirage-block" {>= "0.2" }
-  "mirage-block-unix" {>= "2.1.0" }
+  "mirage-block" {>= "0.2"}
+  "mirage-block-unix" {>= "2.1.0"}
   "cmdliner"
   "sexplib"
   "logs"

--- a/packages/shared-block-ring/shared-block-ring.dev~mirage/opam
+++ b/packages/shared-block-ring/shared-block-ring.dev~mirage/opam
@@ -21,7 +21,7 @@ depends: [
   "lwt"
   "ocamlfind"
   "ounit"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "mirage-block-unix"
   "mirage-clock-unix"
   "sexplib"

--- a/packages/tar-format/tar-format.dev~mirage/opam
+++ b/packages/tar-format/tar-format.dev~mirage/opam
@@ -23,15 +23,15 @@ remove:  ["ocamlfind" "remove" "tar"]
 
 depends: [
   "ocamlfind"
-  "cstruct"           {>= "1.9.0"}
-  "ppx_tools"         {build}
+  "cstruct" {>= "1.9.0"}
+  "ppx_tools" {build}
   "re"
   "result"
   "cmdliner"
-  "ounit"             {test}
+  "ounit" {test}
   "mirage-block-unix" {test}
-  "lwt"               {test}
-  "mirage-types-lwt"  {test}
+  "lwt" {test}
+  "mirage-types-lwt" {test & >= "3.0.0"}
 ]
 depopts: ["lwt" "mirage-types-lwt"]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/vchan/vchan.dev~mirage/opam
+++ b/packages/vchan/vchan.dev~mirage/opam
@@ -29,7 +29,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "ppx_tools" {build}
   "io-page"
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "xenstore" {>= "1.2.2"}
   "xenstore_transport"
   "sexplib"

--- a/packages/vhd-format/vhd-format.dev~mirage/opam
+++ b/packages/vhd-format/vhd-format.dev~mirage/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "ipaddr"
   "io-page"
   "uuidm"


### PR DESCRIPTION
superseed #246

It's not perfect but it is less intrusive.