### PR TITLE
sync functoria opam

### DIFF
--- a/packages/functoria-runtime/functoria-runtime.dev~mirage/opam
+++ b/packages/functoria-runtime/functoria-runtime.dev~mirage/opam
@@ -19,4 +19,4 @@ depends: [
   "cmdliner" {>= "0.9.8"}
   "fmt"
 ]
-available: [ocaml-version >= "4.03"]
+available: [ocaml-version >= "4.02"]


### PR DESCRIPTION
Incidentally this should unbreak 4.02 testing for packages relying on `mirage-runtime` for printers.