### PR TITLE
update crunch (4.03, +rresult); and git (no crc anymore, conflict wit…

### DIFF
--- a/packages/crunch/crunch.dev~mirage/opam
+++ b/packages/crunch/crunch.dev~mirage/opam
@@ -6,6 +6,7 @@ bug-reports:  "https://github.com/mirage/ocaml-crunch/issues"
 license:      "ISC"
 dev-repo:     "https://github.com/mirage/ocaml-crunch.git"
 tags:         ["org:mirage" "org:xapi-project"]
+available:     [ ocaml-version >= "4.03.0" ]
 
 depends: [
   "cmdliner"
@@ -18,6 +19,7 @@ depends: [
   "mirage-types" {test & >= "3.0.0"}
   "mirage-types-lwt" {test & >= "3.0.0"}
   "io-page" {test}
+  "rresult" {test}
 ]
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
 build-test: [

--- a/packages/git/git.dev~mirage/opam
+++ b/packages/git/git.dev~mirage/opam
@@ -32,7 +32,6 @@ depends: [
   "fmt"
   "hex"
   "astring"
-  "crc"
   "alcotest" {test}
   "mirage-types-lwt" {test & >= "3.0.0"}
   "mirage-http" {test}
@@ -64,5 +63,7 @@ conflicts: [
  "alcotest" {< "0.4.0"}
  "camlzip"  {< "1.06"}
  "nocrypto" {< "0.2.0"}
+ "mirage-types"     {< "3.0.0"}
+ "mirage-types-lwt" {< "3.0.0"}
 ]
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
…h mirage-*<3.0.0) -- from upstream

see https://github.com/mirage/ocaml-crunch/pull/30

git updates were motivated by not requiring crc anymore... (see https://github.com/mirage/ocaml-git/pull/166 and https://github.com/mirage/ocaml-git/pull/168)