### PR TITLE
depend on cstruct>="1.9" in mirage-random

### DIFF
--- a/packages/mirage-random/mirage-random.dev~mirage/opam
+++ b/packages/mirage-random/mirage-random.dev~mirage/opam
@@ -16,5 +16,5 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "topkg"      {build & >= "0.7.3"}
-  "cstruct"
+  "cstruct"    {>="1.9.0"}
 ]


### PR DESCRIPTION
opam v2 seems to select an older cstruct and fail sometimes