### PR TITLE
[skip ci] add mirage-stack{-lwt} and mirage-protocols{-lwt}, update opams accor…

### DIFF
--- a/packages/dns/dns.dev~mirage/opam
+++ b/packages/dns/dns.dev~mirage/opam
@@ -22,13 +22,13 @@ tags: [
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix
     "--%{base-unix:enable}%-lwt"
-    "--%{mirage-types-lwt:enable}%-mirage"]
+    "--%{mirage-time-lwt+mirage-stack-lwt+mirage-protocols-lwt+mirage-kv-lwt:enable}%-mirage"]
   ["ocaml" "setup.ml" "-build"]
 ]
 build-test: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix
     "--%{base-unix:enable}%-lwt"
-    "--%{mirage-types-lwt:enable}%-mirage"
+    "--%{mirage-time-lwt+mirage-stack-lwt+mirage-protocol-lwt+mirage-kv-lwt:enable}%-mirage"
     "--enable-tests"]
   ["ocaml" "setup.ml" "-build"]
   ["ocaml" "setup.ml" "-test" "-runner" "sequential"]
@@ -52,12 +52,14 @@ depends: [
   "duration"
   "ounit"       {test}
   "pcap-format" {test}
-  "mirage-runtime" {test}
 ]
 depopts: [
   "async"
   "base-unix"
-  "mirage-types-lwt"
+  "mirage-stack-lwt"
+  "mirage-protocol-lwt"
+  "mirage-kv-lwt"
+  "mirage-time-lwt"
 ]
 conflicts: [
   "mirage-types-lwt" {< "3.0.0"}

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.dev~mirage/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.dev~mirage/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: ["ocaml" "pkg/pkg.ml" "build" "-n" name "--pinned" "%{pinned}%" ]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mirage-protocols"
+  "ipaddr"
+  "lwt"
+  "cstruct"
+]
+
+available: [ ocaml-version >= "4.01.0"]

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.dev~mirage/url
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mirage/mirage-protocols.git"

--- a/packages/mirage-protocols/mirage-protocols.dev~mirage/opam
+++ b/packages/mirage-protocols/mirage-protocols.dev~mirage/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mirage-device"
+  "mirage-flow"
+  "fmt"
+]
+
+available: [ ocaml-version >= "4.01.0"]

--- a/packages/mirage-protocols/mirage-protocols.dev~mirage/url
+++ b/packages/mirage-protocols/mirage-protocols.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mirage/mirage-protocols.git"

--- a/packages/mirage-runtime/mirage-runtime.dev~mirage/opam
+++ b/packages/mirage-runtime/mirage-runtime.dev~mirage/opam
@@ -17,8 +17,9 @@ depends: [
   "topkg"      {build & >= "0.8.0"}
   "ipaddr"             {>= "2.6.0"}
   "functoria-runtime"
+  "fmt"
   "astring"
   "logs"
-  "mirage-types" {>= "3.0.0"}
+  "mirage-types"
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/packages/mirage-stack-lwt/mirage-stack-lwt.dev~mirage/opam
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.dev~mirage/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-stack"
+doc:          "https://mirage.github.io/mirage-stack/"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-stack.git"
+bug-reports:  "https://github.com/mirage/mirage-stack/issues"
+tags:         ["org:mirage"]
+
+build: ["ocaml" "pkg/pkg.ml" "build" "-n" name "--pinned" "%{pinned}%" ]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mirage-stack"
+  "mirage-device"
+  "mirage-protocols-lwt"
+  "ipaddr"
+  "lwt"
+  "cstruct"
+]
+
+available: [ ocaml-version >= "4.01.0"]

--- a/packages/mirage-stack-lwt/mirage-stack-lwt.dev~mirage/url
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mirage/mirage-stack.git"

--- a/packages/mirage-stack/mirage-stack.dev~mirage/opam
+++ b/packages/mirage-stack/mirage-stack.dev~mirage/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-stack"
+doc:          "https://mirage.github.io/mirage-stack/"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-stack.git"
+bug-reports:  "https://github.com/mirage/mirage-stack/issues"
+tags:         ["org:mirage"]
+
+build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
+
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "mirage-device"
+  "mirage-protocols"
+  "fmt"
+]
+
+available: [ ocaml-version >= "4.01.0"]

--- a/packages/mirage-stack/mirage-stack.dev~mirage/url
+++ b/packages/mirage-stack/mirage-stack.dev~mirage/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mirage/mirage-stack.git"

--- a/packages/mirage-types-lwt/mirage-types-lwt.dev~mirage/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.dev~mirage/opam
@@ -18,6 +18,8 @@ depends: [
   "mirage-time-lwt"
   "mirage-random"
   "mirage-flow-lwt"
+  "mirage-protocols-lwt"
+  "mirage-stack-lwt"
   "mirage-console-lwt" {>= "1.2.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}

--- a/packages/mirage-types/mirage-types.dev~mirage/opam
+++ b/packages/mirage-types/mirage-types.dev~mirage/opam
@@ -19,6 +19,8 @@ depends:   [
   "mirage-random"
   "mirage-flow"
   "mirage-console"
+  "mirage-protocols"
+  "mirage-stack"
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0"}
   "mirage-fs" {>= "1.0.0"}

--- a/packages/mirage/mirage.dev~mirage/opam
+++ b/packages/mirage/mirage.dev~mirage/opam
@@ -15,8 +15,8 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind"  {build}
   "topkg"      {build & >= "0.8.0"}
-  "ipaddr"     {>= "2.6.0"}
-  "functoria"  {>= "1.1.0"}
+  "ipaddr"             {>= "2.6.0"}
+  "functoria"          {>= "1.1.0"}
   "bos"
   "astring"
   "logs"
@@ -28,4 +28,4 @@ conflicts: [
   "io-page"  {< "1.4.0"}
   "crunch"   {< "1.2.2"}
 ]
-available: [ocaml-version >= "4.03.0"]
+available: [ocaml-version >= "4.02.3"]

--- a/packages/tcpip/tcpip.dev~mirage/opam
+++ b/packages/tcpip/tcpip.dev~mirage/opam
@@ -45,17 +45,23 @@ depends: [
   "rresult"
   "cstruct" {>= "2.1.0"}
   "ppx_tools" {build}
-  "mirage-types" {>= "3.0.0"}
-  "mirage-types-lwt" {>= "3.0.0"}
-  "mirage-clock-unix" {test & >= "1.0.0"}
+  "mirage-net" {>= "1.0.0"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0" }
+  "mirage-random"
+  "mirage-clock-lwt"
+  "mirage-stack-lwt"
+  "mirage-protocols"
+  "mirage-protocols-lwt"
+  "mirage-time-lwt"
   "ipaddr" {>= "2.2.0"}
   "mirage-profile" {>= "0.5"}
   "mirage-flow" {test}
   "mirage-vnetif" {test & >= "0.2.0"}
   "alcotest" {test}
   "pcap-format" {test}
+  "mirage-clock-unix" {test}
   "fmt"
-  "mirage-runtime"
   "mirage-stdlib-random" {test}
   "lwt" {>= "2.4.7"}
   "logs" {>= "0.6.0"}


### PR DESCRIPTION
…dingly

This PR doesn't contain the forks used in https://github.com/mirage/mirage/pull/764, https://github.com/mirage/mirage-tcpip/pull/283, or https://github.com/mirage/ocaml-dns/pull/121 .  To see passing tests that do, visit https://travis-ci.org/yomimono/mirage-dev/builds/189260358 or see the branch at https://github.com/yomimono/mirage-dev.git#split-tcpip-module-types-consistent .