### PR TITLE
add org:mirage to some packages

### DIFF
--- a/packages/arp/arp.dev~mirage/opam
+++ b/packages/arp/arp.dev~mirage/opam
@@ -7,6 +7,7 @@ dev-repo: "https://github.com/hannesm/arp.git"
 bug-reports: "https://github.com/hannesm/arp/issues"
 license: "ISC"
 available: [ ocaml-version >= "4.02.0"]
+tags: [ "org:mirage" ]
 
 depends: [
   "ocamlfind" {build}

--- a/packages/charrua-core/charrua-core.dev~mirage/opam
+++ b/packages/charrua-core/charrua-core.dev~mirage/opam
@@ -7,6 +7,7 @@ bug-reports: "https://github.com/haesbaert/charrua-core/issues"
 license: "ISC"
 dev-repo: "https://github.com/haesbaert/charrua-core.git"
 available: [ocaml-version >= "4.01" & opam-version >= "1.2"]
+tags: [ "org:mirage" ]
 build: [
   ["sh" "build.sh"]
 ]

--- a/packages/charrua-unix/charrua-unix.dev~mirage/opam
+++ b/packages/charrua-unix/charrua-unix.dev~mirage/opam
@@ -6,6 +6,7 @@ bug-reports: "https://github.com/haesbaert/charrua-unix/issues"
 license: "ISC"
 dev-repo: "https://github.com/haesbaert/charrua-unix.git"
 available: [ocaml-version >= "4.02" & opam-version >= "1.2"]
+tags: [ "org:mirage" ]
 build: [
   ["sh" "build.sh"]
 ]

--- a/packages/functoria-runtime/functoria-runtime.dev~mirage/opam
+++ b/packages/functoria-runtime/functoria-runtime.dev~mirage/opam
@@ -10,6 +10,7 @@ bug-reports:  "https://github.com/mirage/functoria/issues"
 dev-repo:     "https://github.com/mirage/functoria.git"
 doc:          "https://mirage.github.io/functoria/"
 license:      "ISC"
+tags: [ "org:mirage" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" ]
 depends: [

--- a/packages/functoria/functoria.dev~mirage/opam
+++ b/packages/functoria/functoria.dev~mirage/opam
@@ -10,6 +10,7 @@ bug-reports:  "https://github.com/mirage/functoria/issues"
 dev-repo:     "https://github.com/mirage/functoria.git"
 doc:          "https://mirage.github.io/functoria/"
 license:      "ISC"
+tags: [ "org:mirage" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" "--tests" "false" ]
 build-test: [

--- a/packages/git/git.2.0.0/opam
+++ b/packages/git/git.2.0.0/opam
@@ -6,6 +6,7 @@ homepage:     "https://github.com/mirage/ocaml-git"
 bug-reports:  "https://github.com/mirage/ocaml-git/issues"
 dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
+tags:         [ "org:mirage" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
 

--- a/packages/hvsock/hvsock.dev~mirage/opam
+++ b/packages/hvsock/hvsock.dev~mirage/opam
@@ -5,6 +5,7 @@ license: "ISC"
 homepage: "https://github.com/mirage/ocaml-hvsock"
 dev-repo: "https://github.com/mirage/ocaml-hvsock.git"
 bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
+tags: [ "org:mirage" ]
 
 build: [
   ["ocaml" "setup.ml" "-configure" "--%{alcotest:enable}%-tests" ]

--- a/packages/imaplet-lwt/imaplet-lwt.dev~mirage/opam
+++ b/packages/imaplet-lwt/imaplet-lwt.dev~mirage/opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/gregtatcam/imaplet-lwt"
 bug-reports: "https://github.com/gregtatcam/imaplet-lwt/issues"
 dev-repo: "https://github.com/gregtatcam/imaplet-lwt.git"
 license: "MIT"
+tags: [ "org:mirage" ]
 
 build: [
   ["./configure" "--prefix=%{prefix}%"]

--- a/packages/irmin-mirage/irmin-mirage.1.0.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.0.0/opam
@@ -5,6 +5,7 @@ license:      "ISC"
 homepage:     "https://github.com/mirage/irmin"
 bug-reports:  "https://github.com/mirage/irmin/issues"
 dev-repo:     "https://github.com/mirage/irmin.git"
+tags: [ "org:mirage" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
 

--- a/packages/irmin/irmin.1.0.0/opam
+++ b/packages/irmin/irmin.1.0.0/opam
@@ -6,6 +6,7 @@ homepage:     "https://github.com/mirage/irmin"
 bug-reports:  "https://github.com/mirage/irmin/issues"
 dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
+tags:         [ "org:mirage" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
 

--- a/packages/logs-syslog/logs-syslog.dev~mirage/opam
+++ b/packages/logs-syslog/logs-syslog.dev~mirage/opam
@@ -7,6 +7,7 @@ dev-repo: "https://github.com/hannesm/logs-syslog.git"
 bug-reports: "https://github.com/hannesm/logs-syslog/issues"
 license: "ISC"
 available: [ ocaml-version >= "4.03.0"]
+tags: [ "org:mirage" ]
 
 depends: [
   "ocamlfind" {build}

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
@@ -6,6 +6,7 @@ homepage: "https://github.com/mirage/mirage-block"
 dev-repo: "https://github.com/mirage/mirage-block.git"
 bug-reports: "https://github.com/mirage/mirage-block/issues"
 doc: "https://mirage.gitub.io/mirage-block/"
+tags: [ "org:mirage" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "-n" name "--pinned" "%{pinned}%"]
 

--- a/packages/mirage-block/mirage-block.1.0.0/opam
+++ b/packages/mirage-block/mirage-block.1.0.0/opam
@@ -6,6 +6,7 @@ homepage: "https://github.com/mirage/mirage-block"
 dev-repo: "https://github.com/mirage/mirage-block.git"
 bug-reports: "https://github.com/mirage/mirage-block/issues"
 doc: "https://mirage.gitub.io/mirage-block/"
+tags: [ "org:mirage" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "-n" name "--pinned" "%{pinned}%"]
 

--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.dev~mirage/opam
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.dev~mirage/opam
@@ -6,6 +6,7 @@ bug-reports:  "https://github.com/mirage/mirage-bootvar-solo5/issues/"
 dev-repo:     "https://github.com/mirage/mirage-bootvar-solo5.git"
 authors:      [ "Dan Williams <djwillia@us.ibm.com>" "Magnus Skjegstad <magnus@skjegstad.com>" "Martin Lucina <martin@lucina.net>" ]
 license:      "ISC"
+tags: [ "org:mirage" ]
 
 build: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]

--- a/packages/mirage-dns/mirage-dns.dev~mirage/opam
+++ b/packages/mirage-dns/mirage-dns.dev~mirage/opam
@@ -4,6 +4,7 @@ homepage:     "https://github.com/mirage/ocaml-dns"
 dev-repo:     "https://github.com/mirage/ocaml-dns.git"
 bug-reports:  "https://github.com/mirage/ocaml-dns/issues"
 license:      "ISC"
+tags: [ "org:mirage" ]
 authors: [
   "Anil Madhavapeddy"
   "Tim Deegan"

--- a/packages/mirage-net-unix/mirage-net-unix.dev~mirage/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.dev~mirage/opam
@@ -10,6 +10,7 @@ homepage:    "https://github.com/mirage/mirage-net-unix"
 bug-reports: "https://github.com/mirage/mirage-net-unix/issues"
 dev-repo:    "https://github.com/mirage/mirage-net-unix.git"
 license:     "ISC"
+tags: [ "org:mirage" ]
 
 build:   [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
 build-test: [

--- a/packages/mirage-net-xen/mirage-net-xen.dev~mirage/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.dev~mirage/opam
@@ -4,6 +4,7 @@ authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
 homepage:      "https://github.com/mirage/mirage-net-xen"
 bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
 dev-repo:      "https://github.com/mirage/mirage-net-xen.git"
+tags: [ "org:mirage" ]
 build: [ [make] ]
 install: [ [make "install"] ]
 remove: [

--- a/packages/mirage-os-shim/mirage-os-shim.dev~mirage/opam
+++ b/packages/mirage-os-shim/mirage-os-shim.dev~mirage/opam
@@ -6,7 +6,7 @@ doc: "https://pqwy.github.io/mirage-os-shim/doc"
 license: "ISC"
 dev-repo: "https://github.com/pqwy/mirage-os-shim.git"
 bug-reports: "https://github.com/pqwy/mirage-os-shim/issues"
-tags: []
+tags: ["org:mirage"]
 build: [
   "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
           "--with-mirage-unix" "%{mirage-unix:installed}%"

--- a/packages/mirage-qubes/mirage-qubes.dev~mirage/opam
+++ b/packages/mirage-qubes/mirage-qubes.dev~mirage/opam
@@ -5,6 +5,7 @@ license:      "BSD-2-Clause"
 homepage:     "https://github.com/talex5/mirage-qubes"
 bug-reports:  "https://github.com/talex5/mirage-qubes/issues"
 dev-repo:     "https://github.com/talex5/mirage-qubes.git"
+tags: [ "org:mirage" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
         "--with-ipv4" "%{tcpip+ipaddr:installed}%"

--- a/packages/mirage-solo5/mirage-solo5.dev~mirage/opam
+++ b/packages/mirage-solo5/mirage-solo5.dev~mirage/opam
@@ -5,6 +5,7 @@ bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
 dev-repo:     "https://github.com/mirage/mirage-solo5.git"
 authors:       [ "Anil Madhavapeddy <anil@recoil.org>" "Dan Williams <djwillia@us.ibm.com>" "Martin Lucina <martin@lucina.net>" ]
 license:      "ISC"
+tags:         [ "org:mirage" ]
 
 build:   [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
 

--- a/packages/mirage-stdlib-random/mirage-stdlib-random.dev~mirage/opam
+++ b/packages/mirage-stdlib-random/mirage-stdlib-random.dev~mirage/opam
@@ -6,6 +6,7 @@ doc: "https://hannesm.github.io/mirage-stdlib-random/doc"
 dev-repo: "https://github.com/hannesm/mirage-stdlib-random.git"
 bug-reports: "https://github.com/hannesm/mirage-stdlib-random/issues"
 license: "ISC"
+tags: [ "org:mirage" ]
 
 depends: [
   "ocamlfind" {build}

--- a/packages/mirage-unix/mirage-unix.dev~mirage/opam
+++ b/packages/mirage-unix/mirage-unix.dev~mirage/opam
@@ -8,6 +8,7 @@ license:      "part ISC, part LGPL-2.1 with OCaml linking exception, part 3-clau
 build:   [make "unix-build"]
 install: [make "unix-install"   "PREFIX=%{prefix}%"]
 remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]
+tags: [ "org:mirage" ]
 
 depends: [
   "ocamlfind" {build}

--- a/packages/mirage-vnetif/mirage-vnetif.dev~mirage/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.dev~mirage/opam
@@ -7,6 +7,7 @@ bug-reports: "https://github.com/MagnusS/mirage-vnetif/issues/"
 dev-repo: "https://github.com/MagnusS/mirage-vnetif.git"
 license: "ISC"
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
+tags: [ "org:mirage" ]
 
 depends: [
   "ocamlfind"  {build}

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.dev~mirage/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.dev~mirage/opam
@@ -7,6 +7,7 @@ dev-repo: "https://github.com/mirage/mirage-platform.git"
 build: [make "xen-ocaml-build"]
 install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]
 remove: [make "xen-ocaml-uninstall" "PREFIX=%{prefix}%"]
+tags: [ "org:mirage" ]
 depends: [
   "mirage-xen-posix" {>="2.6.0"}
   "conf-pkg-config"

--- a/packages/mirage-xen/mirage-xen.dev~mirage/opam
+++ b/packages/mirage-xen/mirage-xen.dev~mirage/opam
@@ -5,6 +5,7 @@ homepage:     "https://github.com/mirage/mirage-platform"
 bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 dev-repo:     "https://github.com/mirage/mirage-platform.git"
 license:      "part ISC, part LGPL-2.1 with OCaml linking exception, part 3-clause BSD"
+tags: [ "org:mirage" ]
 
 build:   [make "xen-build"]
 install: [make "xen-install"   "PREFIX=%{prefix}%"]

--- a/packages/ocb-stubblr/ocb-stubblr.dev~mirage/opam
+++ b/packages/ocb-stubblr/ocb-stubblr.dev~mirage/opam
@@ -6,7 +6,7 @@ doc: "https://pqwy.github.io/ocb-stubblr/doc"
 license: "ISC"
 dev-repo: "https://github.com/pqwy/ocb-stubblr.git"
 bug-reports: "https://github.com/pqwy/ocb-stubblr/issues"
-tags: ["ocamlbuild"]
+tags: ["ocamlbuild" "org:mirage"]
 available: [ ocaml-version >= "4.01.0" ]
 depends: [
   "ocamlfind" {build}

--- a/packages/protocol-9p/protocol-9p.dev~mirage/opam
+++ b/packages/protocol-9p/protocol-9p.dev~mirage/opam
@@ -6,6 +6,7 @@ homepage:     "https://github.com/mirage/ocaml-9p"
 dev-repo:     "https://github.com/mirage/ocaml-9p.git"
 bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
+tags: [ "org:mirage" ]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
           "--with-lambda-term" "%{lambda-term:installed}%"]

--- a/packages/randomconv/randomconv.dev~mirage/opam
+++ b/packages/randomconv/randomconv.dev~mirage/opam
@@ -6,6 +6,7 @@ doc: "https://hannesm.github.io/randomconv/doc"
 dev-repo: "https://github.com/hannesm/randomconv.git"
 bug-reports: "https://github.com/hannesm/randomconv/issues"
 license: "ISC"
+tags: [ "org:mirage" ]
 
 depends: [
   "ocamlfind" {build}

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.dev~mirage/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.dev~mirage/opam
@@ -5,6 +5,7 @@ bug-reports:  "https://github.com/solo5/solo5/issues"
 dev-repo:     "https://github.com/solo5/solo5.git"
 authors:      [ "Dan Williams <djwillia@us.ibm.com>" "Martin Lucina <martin@lucina.net>" "Ricardo Koller <kollerr@us.ibm.com>"]
 license:      "ISC"
+tags:         [ "org:mirage" ]
 
 build:  [make "ukvm"]
 install:[make "opam-ukvm-install" "PREFIX=%{prefix}%"]

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.dev~mirage/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.dev~mirage/opam
@@ -5,6 +5,7 @@ bug-reports:  "https://github.com/solo5/solo5/issues"
 dev-repo:     "https://github.com/solo5/solo5.git"
 authors:      [ "Dan Williams <djwillia@us.ibm.com>" "Martin Lucina <martin@lucina.net>" "Ricardo Koller <kollerr@us.ibm.com>"]
 license:      "ISC"
+tags:         [ "org:mirage" ]
 
 build:  [make "virtio"]
 install:[make "opam-virtio-install" "PREFIX=%{prefix}%"]

--- a/packages/vchan/vchan.dev~mirage/opam
+++ b/packages/vchan/vchan.dev~mirage/opam
@@ -8,6 +8,7 @@ homepage:    "http://github.com/mirage/ocaml-vchan"
 bug-reports: "http://github.com/mirage/ocaml-vchan/issues"
 dev-repo:    "http://github.com/mirage/ocaml-vchan.git"
 license:     "ISC"
+tags: [ "org:mirage" ]
 
 build: [
   ["./configure" "--%{xen-evtchn+xen-gnt:enable}%-xenctrl" "--%{mirage-xen:enable}%-xen"]


### PR DESCRIPTION
This helps with opam-based analysis of the source code by
identifying package associated with the mirage org.
I have one such effort coming up soon with https://github.com/avsm/git-delve,
hence this PR.