### PR TITLE
add org:mirage tag to mirage libraries

### DIFF
--- a/packages/functoria-runtime/functoria-runtime.dev~mirage/opam
+++ b/packages/functoria-runtime/functoria-runtime.dev~mirage/opam
@@ -10,6 +10,7 @@ bug-reports:  "https://github.com/mirage/functoria/issues"
 dev-repo:     "https://github.com/mirage/functoria.git"
 doc:          "https://mirage.github.io/functoria/"
 license:      "ISC"
+tags:         ["org:mirage"]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" ]
 depends: [

--- a/packages/functoria/functoria.dev~mirage/opam
+++ b/packages/functoria/functoria.dev~mirage/opam
@@ -10,6 +10,7 @@ bug-reports:  "https://github.com/mirage/functoria/issues"
 dev-repo:     "https://github.com/mirage/functoria.git"
 doc:          "https://mirage.github.io/functoria/"
 license:      "ISC"
+tags:         ["org:mirage"]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" "--tests" "false" ]
 build-test: [

--- a/packages/git-http/git-http.2.0.0/opam
+++ b/packages/git-http/git-http.2.0.0/opam
@@ -14,3 +14,4 @@ depends: [
   "cohttp"     {>= "0.19.1"}
 ]
 available: [ocaml-version >= "4.02.3"]
+tags: "org:mirage"

--- a/packages/git-mirage/git-mirage.2.0.0/opam
+++ b/packages/git-mirage/git-mirage.2.0.0/opam
@@ -6,6 +6,7 @@ homepage:     "https://github.com/mirage/ocaml-git"
 bug-reports:  "https://github.com/mirage/ocaml-git/issues"
 dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
+tags:         ["org:mirage"]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
 

--- a/packages/git-unix/git-unix.2.0.0/opam
+++ b/packages/git-unix/git-unix.2.0.0/opam
@@ -6,6 +6,7 @@ homepage:     "https://github.com/mirage/ocaml-git"
 bug-reports:  "https://github.com/mirage/ocaml-git/issues"
 dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
+tags:         ["org:mirage"]
 
 build: [
   "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name "--tests" "false"

--- a/packages/git/git.2.0.0/opam
+++ b/packages/git/git.2.0.0/opam
@@ -6,6 +6,7 @@ homepage:     "https://github.com/mirage/ocaml-git"
 bug-reports:  "https://github.com/mirage/ocaml-git/issues"
 dev-repo:     "https://github.com/mirage/ocaml-git.git"
 doc:          "https://mirage.github.io/ocaml-git/"
+tags:         ["org:mirage"]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
 

--- a/packages/hvsock/hvsock.dev~mirage/opam
+++ b/packages/hvsock/hvsock.dev~mirage/opam
@@ -5,6 +5,7 @@ license: "ISC"
 homepage: "https://github.com/mirage/ocaml-hvsock"
 dev-repo: "https://github.com/mirage/ocaml-hvsock.git"
 bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
+tags: ["org:mirage"]
 
 build: [
   ["ocaml" "setup.ml" "-configure" "--%{alcotest:enable}%-tests" ]

--- a/packages/irmin-git/irmin-git.1.0.0/opam
+++ b/packages/irmin-git/irmin-git.1.0.0/opam
@@ -6,6 +6,7 @@ homepage:     "https://github.com/mirage/irmin"
 bug-reports:  "https://github.com/mirage/irmin/issues"
 dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
+tags:         ["org:mirage"]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
 

--- a/packages/irmin-http/irmin-http.1.0.0/opam
+++ b/packages/irmin-http/irmin-http.1.0.0/opam
@@ -6,6 +6,7 @@ homepage:     "https://github.com/mirage/irmin"
 bug-reports:  "https://github.com/mirage/irmin/issues"
 dev-repo:     "https://github.com/mirage/irmin.git"
 doc:          "https://mirage.github.io/irmin/"
+tags:         ["org:mirage"]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
 

--- a/packages/irmin-mirage/irmin-mirage.1.0.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.0.0/opam
@@ -5,6 +5,7 @@ license:      "ISC"
 homepage:     "https://github.com/mirage/irmin"
 bug-reports:  "https://github.com/mirage/irmin/issues"
 dev-repo:     "https://github.com/mirage/irmin.git"
+tags:         ["org:mirage"]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
 

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
@@ -22,3 +22,4 @@ depends: [
 ]
 
 available: [ocaml-version >= "4.02.0"]
+tags: "org:mirage"

--- a/packages/mirage-block-unix/mirage-block-unix.dev~mirage/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.dev~mirage/opam
@@ -34,3 +34,4 @@ available: [ ocaml-version >= "4.02.3" ]
 depexts: [
  [["alpine"] ["linux-headers"]]
 ]
+tags: "org:mirage"

--- a/packages/mirage-block/mirage-block.1.0.0/opam
+++ b/packages/mirage-block/mirage-block.1.0.0/opam
@@ -17,3 +17,4 @@ depends: [
 ]
 
 available: [ocaml-version >= "4.02.0"]
+tags: "org:mirage"

--- a/packages/mirage-dns/mirage-dns.dev~mirage/opam
+++ b/packages/mirage-dns/mirage-dns.dev~mirage/opam
@@ -23,3 +23,4 @@ depends: [
   "cstruct"          {>= "2.0.0"}
 ]
 available: [ocaml-version >= "4.01.0"]
+tags: "org:mirage"

--- a/packages/mirage-http/mirage-http.dev~mirage/opam
+++ b/packages/mirage-http/mirage-http.dev~mirage/opam
@@ -21,3 +21,4 @@ depends: [
   "cohttp" {>= "0.18.0"}
 ]
 available: [ocaml-version >= "4.00.0"]
+tags: "org:mirage"

--- a/packages/mirage-net-macosx/mirage-net-macosx.dev~mirage/opam
+++ b/packages/mirage-net-macosx/mirage-net-macosx.dev~mirage/opam
@@ -22,3 +22,4 @@ depends: [
   "io-page" {>= "1.4.0"}
   "vmnet"
 ]
+tags: "org:mirage"

--- a/packages/mirage-net-solo5/mirage-net-solo5.dev~mirage/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.dev~mirage/opam
@@ -21,3 +21,4 @@ depends: [
   "logs" {>= "0.6.0"}
 ]
 available: [ ocaml-version >= "4.01.0" ]
+tags: "org:mirage"

--- a/packages/mirage-net-xen/mirage-net-xen.dev~mirage/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.dev~mirage/opam
@@ -28,3 +28,4 @@ depends: [
   "logs" {>= "0.5.0"}
 ]
 available: [ocaml-version >= "4.02.0"]
+tags: "org:mirage"

--- a/packages/mirage-qubes/mirage-qubes.dev~mirage/opam
+++ b/packages/mirage-qubes/mirage-qubes.dev~mirage/opam
@@ -28,3 +28,4 @@ depopts: [
   "tcpip"
 ]
 available: [ocaml-version >= "4.03.0"]
+tags: "org:mirage"

--- a/packages/mirage-solo5/mirage-solo5.dev~mirage/opam
+++ b/packages/mirage-solo5/mirage-solo5.dev~mirage/opam
@@ -19,3 +19,4 @@ depends: [
   "logs"
 ]
 available: [ ocaml-version >= "4.02.3" ]
+tags: "org:mirage"

--- a/packages/mirage-stdlib-random/mirage-stdlib-random.dev~mirage/opam
+++ b/packages/mirage-stdlib-random/mirage-stdlib-random.dev~mirage/opam
@@ -18,3 +18,4 @@ depends: [
 build: [
   [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
 ]
+tags: "org:mirage"

--- a/packages/mirage-unix/mirage-unix.dev~mirage/opam
+++ b/packages/mirage-unix/mirage-unix.dev~mirage/opam
@@ -21,3 +21,4 @@ depends: [
   "logs"
 ]
 available: [ocaml-version >= "4.01.0"]
+tags: "org:mirage"

--- a/packages/mirage-vnetif/mirage-vnetif.dev~mirage/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.dev~mirage/opam
@@ -24,3 +24,4 @@ depends: [
   "duration"
   "result"
 ]
+tags: "org:mirage"

--- a/packages/mirage-www/mirage-www.dev~mirage/opam
+++ b/packages/mirage-www/mirage-www.dev~mirage/opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+tags: ["org:mirage"]
 maintainer: "anil@recoil.org"
 build: [
   [make "MODE=unix" "CFLAGS=--no-opam"]

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.dev~mirage/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.dev~mirage/opam
@@ -7,6 +7,7 @@ dev-repo: "https://github.com/mirage/mirage-platform.git"
 build: [make "xen-ocaml-build"]
 install: [make "xen-ocaml-install" "PREFIX=%{prefix}%"]
 remove: [make "xen-ocaml-uninstall" "PREFIX=%{prefix}%"]
+tags: ["org:mirage"]
 depends: [
   "mirage-xen-posix" {>="2.6.0"}
   "conf-pkg-config"

--- a/packages/mirage-xen/mirage-xen.dev~mirage/opam
+++ b/packages/mirage-xen/mirage-xen.dev~mirage/opam
@@ -5,6 +5,7 @@ homepage:     "https://github.com/mirage/mirage-platform"
 bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 dev-repo:     "https://github.com/mirage/mirage-platform.git"
 license:      "part ISC, part LGPL-2.1 with OCaml linking exception, part 3-clause BSD"
+tags:         ["org:mirage"]
 
 build:   [make "xen-build"]
 install: [make "xen-install"   "PREFIX=%{prefix}%"]

--- a/packages/protocol-9p/protocol-9p.dev~mirage/opam
+++ b/packages/protocol-9p/protocol-9p.dev~mirage/opam
@@ -6,6 +6,7 @@ homepage:     "https://github.com/mirage/ocaml-9p"
 dev-repo:     "https://github.com/mirage/ocaml-9p.git"
 bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
+tags:         ["org:mirage"]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
           "--with-lambda-term" "%{lambda-term:installed}%"]

--- a/packages/vchan/vchan.dev~mirage/opam
+++ b/packages/vchan/vchan.dev~mirage/opam
@@ -51,3 +51,4 @@ depexts: [
  [["debian"] ["libxen-dev" "uuid-dev"]]
  [["ubuntu"] ["libxen-dev" "uuid-dev"]]
 ]
+tags: "org:mirage"


### PR DESCRIPTION
added via opam-tagger in https://github.com/avsm/opam-tagger

this should be mainly mirage-core packages, @yomimono 