### PR TITLE
hvsock: sync with upstream hvsock opam file in mirage-dev

### DIFF
--- a/packages/hvsock/hvsock.dev~mirage/opam
+++ b/packages/hvsock/hvsock.dev~mirage/opam
@@ -21,6 +21,7 @@ remove: ["ocamlfind" "remove" "hvsock"]
 depends: [
   "base-bytes"
   "lwt" {>= "2.4.7"}
+  "bos"
   "logs"
   "fmt"
   "base-unix"


### PR DESCRIPTION
fixes build