### PR TITLE
human-filtered automatic lower bounds

### DIFF
--- a/packages/charrua-client/charrua-client.dev~mirage/opam
+++ b/packages/charrua-client/charrua-client.dev~mirage/opam
@@ -25,7 +25,7 @@ depends: [
   "cstruct"
   "ipaddr"
   "rresult"
-  "mirage-random"
+  "mirage-random" {>= "1.0.0"}
   "duration"
   "logs"
   "tcpip" {>= "dev~mirage"}

--- a/packages/charrua-core/charrua-core.dev~mirage/opam
+++ b/packages/charrua-core/charrua-core.dev~mirage/opam
@@ -19,7 +19,7 @@ depends: [
   "sexplib"
   "menhir"
   "ipaddr" {>= "2.5.0"}
-  "tcpip"
+  "tcpip" {>= "3.0.0"}
   "result"
   "rresult"
 ]

--- a/packages/crunch/crunch.dev~mirage/opam
+++ b/packages/crunch/crunch.dev~mirage/opam
@@ -16,7 +16,7 @@ depends: [
   "bos" {test}
   "cstruct" {test}
   "lwt" {test}
-  "mirage-kv-lwt" {test}
+  "mirage-kv-lwt" {test & >= "1.0.0"}
   "io-page" {test}
   "rresult" {test}
 ]

--- a/packages/datakit-ci/datakit-ci.dev~mirage/opam
+++ b/packages/datakit-ci/datakit-ci.dev~mirage/opam
@@ -26,7 +26,7 @@ depends: [
   "tyxml" {>= "4.0.0"}
   "tls"
   "channel"
-  "conduit"
+  "conduit" {>= "0.15.0"}
   "io-page"
   "pbkdf"
   "webmachine"
@@ -37,7 +37,7 @@ depends: [
   "prometheus-app"
   "lwt" {>= "2.7.0"}
   "ppx_sexp_conv" {build}
-  "crunch" {build}
+  "crunch" {build & >= "2.0.0"}
   "datakit" {test}
   "irmin-unix" {test}
   "alcotest" {test}

--- a/packages/git-mirage/git-mirage.2.0.0/opam
+++ b/packages/git-mirage/git-mirage.2.0.0/opam
@@ -11,14 +11,13 @@ tags:         ["org:mirage"]
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
 
 depends: [
-  "mirage-http"
-  "mirage-flow-lwt"
-  "mirage-channel-lwt"
-  "mirage-fs-lwt"
+  "mirage-http" {>= "3.0.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-channel-lwt" {>= "3.0.0"}
+  "mirage-fs-lwt" {>= "1.0.0"}
   "mirage-conduit" {>= "2.3.0"}
   "result"
   "git-http" {>= "2.0.0"}
-  "git"      {>= "2.0.0"}
+  "git" {>= "2.0.0"}
 ]
-
 available: [ocaml-version >= "4.02.3"]

--- a/packages/hvsock/hvsock.dev~mirage/opam
+++ b/packages/hvsock/hvsock.dev~mirage/opam
@@ -26,13 +26,12 @@ depends: [
   "fmt"
   "base-unix"
   "cmdliner"
-  "mirage-types-lwt" {>="3.0"}
-  "mirage-flow"
+  "mirage-types-lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "1.2.0"}
   "cstruct"
   "duration"
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "alcotest" {test & >= "0.4.0"}
 ]
-
 available: [ ocaml-version >= "4.02.3" ]

--- a/packages/irmin-http/irmin-http.1.0.0/opam
+++ b/packages/irmin-http/irmin-http.1.0.0/opam
@@ -12,10 +12,10 @@ build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
 
 depends: [
   "ocamlbuild" {build}
-  "ocamlfind"  {build}
-  "topkg"      {build & >= "0.7.8"}
-  "crunch"
-  "irmin"  {>= "1.0.0"}
+  "ocamlfind" {build}
+  "topkg" {build & >= "0.7.8"}
+  "crunch" {>= "2.0.0"}
+  "irmin" {>= "1.0.0"}
   "cohttp" {>= "0.18.3"}
 ]
 available: [ocaml-version >= "4.01.0"]

--- a/packages/irmin-mirage/irmin-mirage.1.0.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.0.0/opam
@@ -11,12 +11,12 @@ build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "-n" name]
 
 depends: [
   "ocamlbuild" {build}
-  "ocamlfind"  {build}
-  "topkg"      {build & >= "0.7.8"}
-  "irmin"      {>= "1.0.0"}
-  "irmin-git"  {>= "1.0.0"}
+  "ocamlfind" {build}
+  "topkg" {build & >= "0.7.8"}
+  "irmin" {>= "1.0.0"}
+  "irmin-git" {>= "1.0.0"}
   "git-mirage" {>= "2.0.0"}
   "ptime"
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {>= "1.0.0"}
   "result"
 ]

--- a/packages/mirage-block-ccm/mirage-block-ccm.dev~mirage/opam
+++ b/packages/mirage-block-ccm/mirage-block-ccm.dev~mirage/opam
@@ -18,8 +18,8 @@ depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  "mirage-block"
-  "mirage-block-lwt"
+  "mirage-block" {>= "1.0.0"}
+  "mirage-block-lwt" {>= "1.0.0"}
   "nocrypto" {>= "0.5.1"}
   "io-page" {>= "1.0.0"}
   "ounit" {test}

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "io-page"
   "lwt"
   "logs"
-  "mirage-block"
+  "mirage-block" {>= "1.0.0"}
 ]
 
 available: [ocaml-version >= "4.02.0"]

--- a/packages/mirage-block/mirage-block.1.0.0/opam
+++ b/packages/mirage-block/mirage-block.1.0.0/opam
@@ -11,9 +11,9 @@ build: ["ocaml" "pkg/pkg.ml" "build" "-n" name "--pinned" "%{pinned}%"]
 
 depends: [
   "ocamlbuild" {build}
-  "ocamlfind"  {build}
-  "topkg"      {build}
-  "mirage-device"
+  "ocamlfind" {build}
+  "topkg" {build}
+  "mirage-device" {>= "1.0.0"}
 ]
 
 available: [ocaml-version >= "4.02.0"]

--- a/packages/mirage-channel/mirage-channel-lwt.dev~mirage/opam
+++ b/packages/mirage-channel/mirage-channel-lwt.dev~mirage/opam
@@ -24,5 +24,7 @@ depends: [
   "logs"
   "alcotest" {test}
 ]
-conflicts: [ "tcpip" {<"2.5.0"} ]
+conflicts: [
+  "tcpip" {< "3.0.0"}
+]
 available: [ ocaml-version >= "4.01.0"]

--- a/packages/mirage-channel/mirage-channel.dev~mirage/opam
+++ b/packages/mirage-channel/mirage-channel.dev~mirage/opam
@@ -16,6 +16,7 @@ depends: [
   "topkg" {build & >= "0.8.0"}
   "mirage-flow" {>= "1.2.0"}
 ]
-conflicts: [ "tcpip" {<"2.5.0"} ]
-
+conflicts: [
+  "tcpip" {< "3.0.0"}
+]
 available: [ ocaml-version >= "4.01.0"]

--- a/packages/mirage-clock/mirage-clock.1.2.0/opam
+++ b/packages/mirage-clock/mirage-clock.1.2.0/opam
@@ -12,6 +12,6 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device"
+  "mirage-device" {>= "1.0.0"}
 ]
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%" ]

--- a/packages/mirage-console/mirage-console-xen-backend.dev~mirage/opam
+++ b/packages/mirage-console/mirage-console-xen-backend.dev~mirage/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg"      {build & >= "0.8.0"}
   "mirage-console-lwt" {>= "2.2.0"}
-  "mirage-console-xen-proto"
+  "mirage-console-xen-proto" {>= "2.2.0"}
   "lwt"
   "xenstore" "xen-evtchn" "xen-gnt" "shared-memory-ring"
 ]

--- a/packages/mirage-console/mirage-console-xen-cli.dev~mirage/opam
+++ b/packages/mirage-console/mirage-console-xen-cli.dev~mirage/opam
@@ -19,8 +19,11 @@ depends: [
   "ipaddr"
   "io-page"
   "cmdliner"
-  "mirage-unix" {>="1.1.0"}
-  "xenstore_transport" "xenctrl" "xen-gnt"
-  "mirage-console-xen-backend" "mirage-console-unix"
+  "mirage-unix" {>= "1.1.0"}
+  "xenstore_transport"
+  "xenctrl"
+  "xen-gnt"
+  "mirage-console-xen-backend" {>= "2.2.0"}
+  "mirage-console-unix" {>= "2.2.0"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/mirage-console/mirage-console-xen.dev~mirage/opam
+++ b/packages/mirage-console/mirage-console-xen.dev~mirage/opam
@@ -15,9 +15,9 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
   "mirage-console-lwt" {>= "2.2.0"}
-  "mirage-console-xen-proto"
+  "mirage-console-xen-proto" {>= "2.2.0"}
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen"
+  "mirage-xen" {>= "3.0.0"}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/packages/mirage-console/mirage-console.2.2.0/opam
+++ b/packages/mirage-console/mirage-console.2.2.0/opam
@@ -13,7 +13,7 @@ build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
-  "topkg"      {build & >= "0.8.0"}
-  "mirage-device"
-  "mirage-flow"
+  "topkg" {build & >= "0.8.0"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
 ]

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.dev~mirage/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.dev~mirage/opam
@@ -12,12 +12,12 @@ build: ["ocaml" "pkg/pkg.ml" "build"
        "--pkg-name" name "--pinned" "%{pinned}%"]
 
 depends: [
-  "ocamlfind"  {build}
+  "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg"      {build & >= "0.7.3"}
+  "topkg" {build & >= "0.7.3"}
   "fmt"
   "lwt"
   "cstruct" {>= "2.0.0"}
-  "mirage-clock"
-  "mirage-flow"
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-flow" {>= "1.2.0"}
 ]

--- a/packages/mirage-flow-unix/mirage-flow-unix.dev~mirage/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.dev~mirage/opam
@@ -23,8 +23,8 @@ depends: [
   "topkg"      {build & >= "0.7.3"}
   "alcotest"   {test}
   "fmt"
-  "mirage-flow"
-  "mirage-flow-lwt"
+  "mirage-flow" {>= "1.2.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
   "lwt"
   "cstruct" {>= "2.3.0"}
 ]

--- a/packages/mirage-fs-unix/mirage-fs-unix.dev~mirage/opam
+++ b/packages/mirage-fs-unix/mirage-fs-unix.dev~mirage/opam
@@ -16,13 +16,13 @@ build-test: [
 depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.4.0"}
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {>= "1.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
   "lwt"
   "result"
-  "rresult"           {test}
-  "mirage-clock-unix" {test}
-  "alcotest"          {test & >= "0.7.1"}
-  "ptime"             {test}
+  "rresult" {test}
+  "mirage-clock-unix" {test & >= "1.2.0"}
+  "alcotest" {test & >= "0.7.1"}
+  "ptime" {test}
 ]
 available: [ ocaml-version >= "4.02.3"]

--- a/packages/mirage-fs/mirage-fs-lwt.1.0.0/opam
+++ b/packages/mirage-fs/mirage-fs-lwt.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "mirage-fs" {>= "1.0.0"}
-  "mirage-kv-lwt"
+  "mirage-kv-lwt" {>= "1.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]

--- a/packages/mirage-fs/mirage-fs.1.0.0/opam
+++ b/packages/mirage-fs/mirage-fs.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "fmt"
-  "mirage-device"
+  "mirage-device" {>= "1.0.0"}
 ]
 
 available: [ ocaml-version >= "4.01.0"]

--- a/packages/mirage-http/mirage-http.dev~mirage/opam
+++ b/packages/mirage-http/mirage-http.dev~mirage/opam
@@ -13,9 +13,9 @@ depends: [
   "ocamlbuild" {build}
   "topkg"      {build}
   "result"
-  "mirage-flow-lwt"
-  "mirage-channel-lwt"
-  "conduit"
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-channel-lwt" {>= "3.0.0"}
+  "conduit" {>= "0.15.0"}
   "mirage-conduit" {>= "2.2.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {>= "0.18.0"}

--- a/packages/mirage-kv-lwt/mirage-kv-lwt.1.0.0/opam
+++ b/packages/mirage-kv-lwt/mirage-kv-lwt.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-kv"
+  "mirage-kv" {>= "1.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}
 ]

--- a/packages/mirage-kv/mirage-kv.1.0.0/opam
+++ b/packages/mirage-kv/mirage-kv.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device"
+  "mirage-device" {>= "1.0.0"}
   "fmt"
 ]
 

--- a/packages/mirage-net/mirage-net.1.0.0/opam
+++ b/packages/mirage-net/mirage-net.1.0.0/opam
@@ -15,6 +15,6 @@ build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
-  "topkg"      {build & >= "0.8.0"}
-  "mirage-device"
+  "topkg" {build & >= "0.8.0"}
+  "mirage-device" {>= "1.0.0"}
 ]

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.dev~mirage/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.dev~mirage/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-protocols"
+  "mirage-protocols" {>= "1.0.0"}
   "ipaddr"
   "lwt"
   "cstruct" {>= "1.9.0"}

--- a/packages/mirage-protocols/mirage-protocols.dev~mirage/opam
+++ b/packages/mirage-protocols/mirage-protocols.dev~mirage/opam
@@ -14,8 +14,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device"
-  "mirage-flow"
+  "mirage-device" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
   "fmt"
 ]
 

--- a/packages/mirage-qubes/mirage-qubes.dev~mirage/opam
+++ b/packages/mirage-qubes/mirage-qubes.dev~mirage/opam
@@ -18,7 +18,7 @@ depends: [
   "vchan" { >= "2.0.0" }
   "xen-evtchn"
   "xen-gnt"
-  "mirage-xen"
+  "mirage-xen" {>= "3.0.0"}
   "lwt"
   "mirage-types-lwt" { >= "3.0.0" }
   "logs" { >= "0.5.0" }

--- a/packages/mirage-stack-lwt/mirage-stack-lwt.dev~mirage/opam
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.dev~mirage/opam
@@ -14,7 +14,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-stack"
+  "mirage-stack" {>= "1.0.0"}
   "ipaddr"
   "lwt"
   "cstruct" {>= "1.9.0"}

--- a/packages/mirage-stack/mirage-stack.dev~mirage/opam
+++ b/packages/mirage-stack/mirage-stack.dev~mirage/opam
@@ -14,8 +14,8 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}
-  "mirage-device"
-  "mirage-protocols"
+  "mirage-device" {>= "1.0.0"}
+  "mirage-protocols" {>= "1.0.0"}
   "fmt"
 ]
 

--- a/packages/mirage-time-lwt/mirage-time-lwt.dev~mirage/opam
+++ b/packages/mirage-time-lwt/mirage-time-lwt.dev~mirage/opam
@@ -16,7 +16,7 @@ build: ["ocaml" "pkg/pkg.ml" "build"
 depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
-  "topkg"      {build & >= "0.8.0"}
-  "mirage-time"
+  "topkg" {build & >= "0.8.0"}
+  "mirage-time" {>= "1.0.0"}
   "lwt"
 ]

--- a/packages/mirage-time/mirage-time.dev~mirage/opam
+++ b/packages/mirage-time/mirage-time.dev~mirage/opam
@@ -15,6 +15,6 @@ build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
 depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
-  "topkg"      {build & >= "0.8.0"}
-  "mirage-device"
+  "topkg" {build & >= "0.8.0"}
+  "mirage-device" {>= "1.0.0"}
 ]

--- a/packages/mirage-types-lwt/mirage-types-lwt.dev~mirage/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.dev~mirage/opam
@@ -15,17 +15,17 @@ depends: [
   "cstruct" {>="1.4.0"}
   "io-page" {>="1.4.0"}
   "ipaddr"
-  "mirage-types" {>="3.0.0"}
-  "mirage-clock-lwt"
-  "mirage-time-lwt"
-  "mirage-random"
-  "mirage-flow-lwt"
-  "mirage-protocols-lwt"
-  "mirage-stack-lwt"
+  "mirage-types" {>= "3.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-protocols-lwt" {>= "1.0.0"}
+  "mirage-stack-lwt" {>= "1.0.0"}
   "mirage-console-lwt" {>= "1.2.0"}
   "mirage-block-lwt" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
-  "mirage-kv-lwt"
-  "mirage-channel-lwt"
+  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-channel-lwt" {>= "3.0.0"}
 ]

--- a/packages/mirage-types/mirage-types.dev~mirage/opam
+++ b/packages/mirage-types/mirage-types.dev~mirage/opam
@@ -10,19 +10,19 @@ tags:         ["org:mirage" "org:xapi-project"]
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 depends:   [
   "ocamlbuild" {build}
-  "ocamlfind"  {build}
-  "topkg"      {build & >= "0.8.0"}
-  "mirage-device"
-  "mirage-time"
+  "ocamlfind" {build}
+  "topkg" {build & >= "0.8.0"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-time" {>= "1.0.0"}
   "mirage-clock" {>= "1.2.0"}
-  "mirage-random"
-  "mirage-flow"
-  "mirage-console"
-  "mirage-protocols"
-  "mirage-stack"
+  "mirage-random" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
+  "mirage-console" {>= "2.2.0"}
+  "mirage-protocols" {>= "1.0.0"}
+  "mirage-stack" {>= "1.0.0"}
   "mirage-block" {>= "1.0.0"}
   "mirage-net" {>= "1.0.0"}
   "mirage-fs" {>= "1.0.0"}
-  "mirage-kv"
-  "mirage-channel"
+  "mirage-kv" {>= "1.0.0"}
+  "mirage-channel" {>= "3.0.0"}
 ]

--- a/packages/mirage-vnetif/mirage-vnetif.dev~mirage/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.dev~mirage/opam
@@ -16,9 +16,9 @@ depends: [
   "ocamlbuild" {build}
   "topkg"      {build}
   "lwt"
-  "mirage-time-lwt"
+  "mirage-time-lwt" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
-  "mirage-net-lwt"   {>= "1.0.0"}
+  "mirage-net-lwt" {>= "1.0.0"}
   "cstruct"
   "ipaddr"
   "io-page"

--- a/packages/mirage-xen/mirage-xen.dev~mirage/opam
+++ b/packages/mirage-xen/mirage-xen.dev~mirage/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlbuild" {build}
   "cstruct" {>= "1.0.1"}
   "io-page" {>= "1.5.0"}
-  "mirage-clock-freestanding"
+  "mirage-clock-freestanding" {>= "1.2.0"}
   "lwt" {>= "2.4.3"}
   "shared-memory-ring" {>= "1.0.0"}
   "xenstore" {>= "1.2.5"}

--- a/packages/nbd/nbd.dev~mirage/opam
+++ b/packages/nbd/nbd.dev~mirage/opam
@@ -31,7 +31,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "cmdliner"
   "sexplib"
-  "mirage-block-unix"
+  "mirage-block-unix" {>= "2.5.0"}
   "io-page"
   "mirage" {>= "1.1.0"}
   "uri"

--- a/packages/protocol-9p/protocol-9p.dev~mirage/opam
+++ b/packages/protocol-9p/protocol-9p.dev~mirage/opam
@@ -23,9 +23,9 @@ depends: [
   "sexplib" {> "113.00.00" }
   "result"
   "rresult"
-  "mirage-flow-lwt"
-  "mirage-kv-lwt"
-  "mirage-channel-lwt"
+  "mirage-flow-lwt" {>= "1.2.0"}
+  "mirage-kv-lwt" {>= "1.0.0"}
+  "mirage-channel-lwt" {>= "3.0.0"}
   "lwt" {>= "2.4.7"}
   "base-unix"
   "cmdliner"

--- a/packages/qcow/qcow.dev~mirage/opam
+++ b/packages/qcow/qcow.dev~mirage/opam
@@ -37,7 +37,7 @@ depends: [
   "ppx_sexp_conv" {build}
   "ppx_type_conv" {build}
   "ounit" {test}
-  "mirage-block-ramdisk" {test}
+  "mirage-block-ramdisk" {test & >= "0.3"}
   "ezjsonm" {test}
   "nbd" {test & >= "2.0.1"}
 ]

--- a/packages/shared-block-ring/shared-block-ring.dev~mirage/opam
+++ b/packages/shared-block-ring/shared-block-ring.dev~mirage/opam
@@ -22,8 +22,8 @@ depends: [
   "ocamlfind"
   "ounit"
   "mirage-types-lwt" {>= "3.0.0"}
-  "mirage-block-unix"
-  "mirage-clock-unix"
+  "mirage-block-unix" {>= "2.5.0"}
+  "mirage-clock-unix" {>= "1.2.0"}
   "sexplib"
   "io-page"
   "io-page-unix"

--- a/packages/tar-format/tar-format.dev~mirage/opam
+++ b/packages/tar-format/tar-format.dev~mirage/opam
@@ -28,10 +28,10 @@ depends: [
   "re"
   "result"
   "cmdliner"
-  "ounit"             {test}
-  "mirage-block-unix" {test}
-  "lwt"               {test}
-  "mirage-types-lwt"  {test & >= "3.0.0"}
+  "ounit" {test}
+  "mirage-block-unix" {test & >= "2.5.0"}
+  "lwt" {test}
+  "mirage-types-lwt" {test & >= "3.0.0"}
 ]
 depopts: ["lwt" "mirage-types-lwt" "mirage-block"]
 available: [ ocaml-version >= "4.01.0" ]

--- a/packages/tcpip/tcpip.dev~mirage/opam
+++ b/packages/tcpip/tcpip.dev~mirage/opam
@@ -47,22 +47,22 @@ depends: [
   "ppx_tools" {build}
   "mirage-net" {>= "1.0.0"}
   "mirage-net-lwt" {>= "1.0.0"}
-  "mirage-clock" {>= "1.2.0" }
-  "mirage-random"
-  "mirage-clock-lwt"
-  "mirage-stack-lwt"
-  "mirage-protocols"
-  "mirage-protocols-lwt"
-  "mirage-time-lwt"
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-stack-lwt" {>= "1.0.0"}
+  "mirage-protocols" {>= "1.0.0"}
+  "mirage-protocols-lwt" {>= "1.0.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0"}
   "mirage-profile" {>= "0.5"}
-  "mirage-flow" {test}
+  "mirage-flow" {test & >= "1.2.0"}
   "mirage-vnetif" {test & >= "0.2.0"}
   "alcotest" {test}
   "pcap-format" {test}
-  "mirage-clock-unix" {test}
+  "mirage-clock-unix" {test & >= "1.2.0"}
   "fmt"
-  "mirage-random" {test}
+  "mirage-random" {test & >= "1.0.0"}
   "lwt" {>= "2.4.7"}
   "logs" {>= "0.6.0"}
   "duration"


### PR DESCRIPTION
Add lower bounds to dependencies on packages soon to be released, where not already present.  A map of package names to version numbers may be of more general interest and is available for copy/pasting at https://github.com/yomimono/upperbound-constrainer/blob/mass-update-mirageos3/src/packages.ml#L5 .