### PR TITLE
Changed git protocol in all url files to https

### DIFF
--- a/packages/charrua-core/charrua-core.dev~mirage/url
+++ b/packages/charrua-core/charrua-core.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/haesbaert/charrua-core.git"
+git: "https://github.com/haesbaert/charrua-core.git"

--- a/packages/charrua-unix/charrua-unix.dev~mirage/url
+++ b/packages/charrua-unix/charrua-unix.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/haesbaert/charrua-unix.git"
+git: "https://github.com/haesbaert/charrua-unix.git"

--- a/packages/dns/dns.dev~mirage/url
+++ b/packages/dns/dns.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/mirage/ocaml-dns.git"
+git: "https://github.com/mirage/ocaml-dns.git"

--- a/packages/github/github.dev~mirage/url
+++ b/packages/github/github.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/mirage/ocaml-github"
+git: "https://github.com/mirage/ocaml-github"

--- a/packages/github/github.dev~mirage/url
+++ b/packages/github/github.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "https://github.com/mirage/ocaml-github"
+git: "https://github.com/mirage/ocaml-github.git"

--- a/packages/mirage-dns/mirage-dns.dev~mirage/url
+++ b/packages/mirage-dns/mirage-dns.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/mirage/ocaml-dns.git"
+git: "https://github.com/mirage/ocaml-dns.git"

--- a/packages/mirage-entropy/mirage-entropy.dev~mirage/url
+++ b/packages/mirage-entropy/mirage-entropy.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/mirage/mirage-entropy.git"
+git: "https://github.com/mirage/mirage-entropy.git"

--- a/packages/mirage-net-solo5/mirage-net-solo5.dev~mirage/url
+++ b/packages/mirage-net-solo5/mirage-net-solo5.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/mirage/mirage-net-solo5.git"
+git: "https://github.com/mirage/mirage-net-solo5.git"

--- a/packages/mirage-os-shim/mirage-os-shim.dev~mirage/url
+++ b/packages/mirage-os-shim/mirage-os-shim.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/pqwy/mirage-os-shim.git"
+git: "https://github.com/pqwy/mirage-os-shim.git"

--- a/packages/mirage-www/mirage-www.dev~mirage/url
+++ b/packages/mirage-www/mirage-www.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/mirage/mirage-www"
+git: "https://github.com/mirage/mirage-www"

--- a/packages/mirage-www/mirage-www.dev~mirage/url
+++ b/packages/mirage-www/mirage-www.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "https://github.com/mirage/mirage-www"
+git: "https://github.com/mirage/mirage-www.git"

--- a/packages/nocrypto/nocrypto.dev~mirage/url
+++ b/packages/nocrypto/nocrypto.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/mirleft/ocaml-nocrypto.git"
+git: "https://github.com/mirleft/ocaml-nocrypto.git"

--- a/packages/ocaml-freestanding/ocaml-freestanding.dev~mirage/url
+++ b/packages/ocaml-freestanding/ocaml-freestanding.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/mirage/ocaml-freestanding"
+git: "https://github.com/mirage/ocaml-freestanding"

--- a/packages/ocaml-freestanding/ocaml-freestanding.dev~mirage/url
+++ b/packages/ocaml-freestanding/ocaml-freestanding.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "https://github.com/mirage/ocaml-freestanding"
+git: "https://github.com/mirage/ocaml-freestanding.git"

--- a/packages/prometheus-app/prometheus-app.dev~mirage/url
+++ b/packages/prometheus-app/prometheus-app.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "https://github.com/docker/datakit"
+git: "https://github.com/docker/datakit.git"

--- a/packages/prometheus-app/prometheus-app.dev~mirage/url
+++ b/packages/prometheus-app/prometheus-app.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/docker/datakit"
+git: "https://github.com/docker/datakit"

--- a/packages/prometheus/prometheus.dev~mirage/url
+++ b/packages/prometheus/prometheus.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "https://github.com/docker/datakit"
+git: "https://github.com/docker/datakit.git"

--- a/packages/prometheus/prometheus.dev~mirage/url
+++ b/packages/prometheus/prometheus.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/docker/datakit"
+git: "https://github.com/docker/datakit"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.dev~mirage/url
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/solo5/solo5"
+git: "https://github.com/solo5/solo5"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.dev~mirage/url
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "https://github.com/solo5/solo5"
+git: "https://github.com/solo5/solo5.git"

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.dev~mirage/url
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "git://github.com/solo5/solo5"
+git: "https://github.com/solo5/solo5"

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.dev~mirage/url
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.dev~mirage/url
@@ -1,1 +1,1 @@
-git: "https://github.com/solo5/solo5"
+git: "https://github.com/solo5/solo5.git"


### PR DESCRIPTION
Some url files were using git:// as protocol instead of https. In those
cases, Git connects to the repository server on port 9418, which might
not work if you are behind a more restrictive firewall setup.