### PR TITLE
Add a Dockerfile to reproduce a travis build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# For reference, this is what travis currently runs
+
+FROM ubuntu:trusty
+
+RUN apt-get update -qq && apt-get install wget build-essential software-properties-common -y
+
+COPY . /src
+WORKDIR /src
+
+# Environment variables from travis
+ENV OCAML_VERSION=4.04
+ENV OPAM_VERSION=1.2.2
+ENV MODE=unix
+ENV OPAM_INIT=true
+ENV OPAM_SWITCH=system
+ENV BASE_REMOTE=git://github.com/ocaml/opam-repository
+ENV UPDATE_GCC_BINUTILS=0
+ENV UBUNTU_TRUSTY=0
+ENV INSTALL_XQUARTZ=true
+ENV TRAVIS_OS_NAME=linux
+
+RUN wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-ocaml.sh
+RUN bash -e .travis-ocaml.sh
+RUN bash -ex .travis-ci.sh


### PR DESCRIPTION
This reproduces the recent `tls.lwt` issue. Ideally we would have some tool which parses (or generates) the `.travis.yml` and this `Dockerfile` to keep them in sync.

Signed-off-by: David Scott <dave@recoil.org>