### PR TITLE
Add packages affected by keepalives

### DIFF
--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.3.0/opam
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.3.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta9" }
+  "mirage-protocols" { >= "1.1.0" }
+  "ipaddr"
+  "lwt"
+  "cstruct" {>= "1.9.0"}
+]
+
+available: [ ocaml-version >= "4.03.0"]

--- a/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.3.0/url
+++ b/packages/mirage-protocols-lwt/mirage-protocols-lwt.1.3.0/url
@@ -1,0 +1,1 @@
+git: "git://github.com/djs55/mirage-protocols.git#keepalive"

--- a/packages/mirage-protocols/mirage-protocols.1.3.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.3.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta9"}
+  "mirage-device"
+  "mirage-flow"
+  "fmt"
+  "duration"
+]
+
+available: [ ocaml-version >= "4.03.0"]

--- a/packages/mirage-protocols/mirage-protocols.1.3.0/url
+++ b/packages/mirage-protocols/mirage-protocols.1.3.0/url
@@ -1,0 +1,1 @@
+git: "git://github.com/djs55/mirage-protocols.git#keepalive"

--- a/packages/mirage-stack-lwt/mirage-stack-lwt.1.2.0/opam
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.1.2.0/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-stack"
+doc:          "https://mirage.github.io/mirage-stack/"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-stack.git"
+bug-reports:  "https://github.com/mirage/mirage-stack/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta9"}
+  "mirage-stack" {>= "1.0.0"}
+  "ipaddr"
+  "lwt"
+  "cstruct" {>= "2.4.0"}
+]
+
+available: [ ocaml-version >= "4.03.0"]

--- a/packages/mirage-stack-lwt/mirage-stack-lwt.1.2.0/url
+++ b/packages/mirage-stack-lwt/mirage-stack-lwt.1.2.0/url
@@ -1,0 +1,1 @@
+git: "git://github.com/djs55/mirage-stack#keepalive"

--- a/packages/mirage-stack/mirage-stack.1.2.0/opam
+++ b/packages/mirage-stack/mirage-stack.1.2.0/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-stack"
+doc:          "https://mirage.github.io/mirage-stack/"
+license:      "ISC"
+dev-repo:     "https://github.com/mirage/mirage-stack.git"
+bug-reports:  "https://github.com/mirage/mirage-stack/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "jbuilder" "subst" ] {pinned}
+  [ "jbuilder" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta9"}
+  "mirage-device" {>= "1.0.0"}
+  "mirage-protocols" {>= "1.3.0"}
+  "fmt"
+]
+
+available: [ ocaml-version >= "4.03.0" ]

--- a/packages/mirage-stack/mirage-stack.1.2.0/url
+++ b/packages/mirage-stack/mirage-stack.1.2.0/url
@@ -1,0 +1,1 @@
+git: "git://github.com/djs55/mirage-stack#keepalive"

--- a/packages/tcpip/tcpip.3.4.0/opam
+++ b/packages/tcpip/tcpip.3.4.0/opam
@@ -1,0 +1,51 @@
+opam-version: "1.2"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [
+  ["jbuilder" "runtest" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder"     {build & >="1.0+beta10"}
+  "configurator" {build}
+  "rresult"
+  "cstruct" {>= "3.0.2"}
+  "cstruct-lwt"
+  "mirage-net" {>= "1.0.0"}
+  "mirage-net-lwt" {>= "1.0.0"}
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-random" {>= "1.0.0"}
+  "mirage-clock-lwt" {>= "1.2.0"}
+  "mirage-stack-lwt" {>= "1.2.0"}
+  "mirage-protocols" {>= "1.3.0"}
+  "mirage-protocols-lwt" {>= "1.3.0"}
+  "mirage-time-lwt" {>= "1.0.0"}
+  "ipaddr" {>= "2.2.0"}
+  "mirage-profile" {>= "0.5"}
+  "fmt"
+  "lwt" {>= "3.0.0"}
+  "logs" {>= "0.6.0"}
+  "duration"
+  "io-page-unix"
+  "randomconv"
+  "mirage-flow" {test & >= "1.2.0"}
+  "mirage-vnetif" {test & >= "0.4.0"}
+  "alcotest" {test & >="0.7.0"}
+  "pcap-format" {test}
+  "mirage-clock-unix" {test & >= "1.2.0"}
+]
+available: [ocaml-version >= "4.03.0"]

--- a/packages/tcpip/tcpip.3.4.0/url
+++ b/packages/tcpip/tcpip.3.4.0/url
@@ -1,0 +1,1 @@
+git: "git://github.com/djs55/mirage-tcpip.git#keepalive2"

--- a/packages/vpnkit/vpnkit.0.2.0/opam
+++ b/packages/vpnkit/vpnkit.0.2.0/opam
@@ -1,0 +1,67 @@
+opam-version: "1.2"
+maintainer: "David Scott <dave.scott@docker.com>"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "David Scott <dave.scott@docker.com>"
+  "David Sheets <dsheets@docker.com>"
+  "Gaetan de Villele <gdevillele@gmail.com>"
+  "Ian Campbell <ian.campbell@docker.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Mindy Preston <mindy.preston@docker.com>"
+  "Sebastiaan van Stijn <github@gone.nl>"
+  "Thomas Gazagnaire <thomas@gazagnaire.com>"
+  "Thomas Leonard <thomas.leonard@docker.com>"
+]
+homepage:     "https://github.com/moby/vpnkit"
+bug-reports:  "https://github.com/moby/vpnkit/issues"
+dev-repo:     "https://github.com/moby/vpnkit.git"
+doc:          "https://moby.github.io/vpnkit/"
+
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "jbuilder" {build & >="1.0+beta10"}
+  "alcotest"   {test}
+  "result"
+  "tar" {>= "0.8.0"}
+  "ipaddr"
+  "lwt" {>= "2.7.0"}
+  "uwt" {>= "0.0.4"}
+  "tcpip" {>= "3.4.0"}
+  "dns" {>= "0.19.1"}
+  "dns-lwt"
+  "dnssd" {>= "0.2"}
+  "dns-forward"
+  "cstruct-lwt" {>= "3.0.0"}
+  "datakit-server" {>= "0.11.0"}
+  "datakit-server-9p" {>= "0.11.0"}
+  "hashcons" {>= "1.0.1"}
+  "pcap-format" {>= "0.4.0"}
+  "cmdliner"
+  "charrua-core" {>= "0.9"}
+  "charrua-client-mirage" {test}
+  "named-pipe" {>= "0.4.0"}
+  "hvsock" {>= "0.13.0"}
+  "asl"
+  "win-eventlog"
+  "fd-send-recv" {>= "1.0.3"}
+  "logs"
+  "fmt"
+  "astring"
+  "mirage-flow-lwt" {>= "1.4.0"}
+  "mirage-time-lwt" {>= "1.1.0"}
+  "mirage-time-unix"
+  "mirage-protocols" {>= "1.3.0"}
+  "mirage-channel" {>= "3.0.1"}
+  "mirage-console-unix"
+  "mirage-clock-unix"
+  "cohttp-lwt" {>= "0.99.0"}
+  "mirage-dns"
+  "protocol-9p-unix" {>= "0.11.2"}
+  "mirage-vnetif" {>= "0.4.0"}
+  "uuidm"
+  "ezjsonm"
+]

--- a/packages/vpnkit/vpnkit.0.2.0/url
+++ b/packages/vpnkit/vpnkit.0.2.0/url
@@ -1,0 +1,1 @@
+git: "git://github.com/djs55/vpnkit.git#keepalive"


### PR DESCRIPTION
See [mirage/mirage-protocols#8]

This will allow the CI to test the interface change properly before we merge/release.

Signed-off-by: David Scott <dave@recoil.org>