### PR TITLE
Remove conflicts between ocaml-git/mimic

### DIFF
--- a/packages/mimic/mimic.0.0.3/opam
+++ b/packages/mimic/mimic.0.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A simple protocol dispatcher"
+description: "A middleware to dispatch protocols"
+maintainer: ["romain.calascibetta@gmail.com"]
+authors: "Romain Calascibetta"
+license: "ISC"
+homepage: "https://github.com/dinosaure/mimic"
+doc: "https://dinosaure.github.io/mimic/"
+bug-reports: "https://github.com/dinosaure/mimic/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "bigarray-compat" {with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "git" {< "3.4.0"}
+]
+dev-repo: "git+https://github.com/dinosaure/mimic.git"
+x-commit-hash: "40d67317a108af764874be5d0b1c1d4126a8ee6e"
+url {
+  src:
+    "https://github.com/dinosaure/mimic/releases/download/0.0.3/mimic-0.0.3.tbz"
+  checksum: [
+    "sha256=e4743cd2e4f8242eb1ce9d8086fd2affba0eb6a62131309ffa279108bd3dbbcb"
+    "sha512=8c3c0508c09af4694f16738039965f36909952a694a8203356aa002810c9cec589510544f053377e9e43fa902c59d8cd00aa02dda57e8cdba02ee0e20b4f2bbb"
+  ]
+}


### PR DESCRIPTION
Add a conflict between `ocaml-git` and `mimic` to disallow `opam-monorepo` to download twice `mimic`.
Test with https://github.com/mirage/mirage-skeleton/pull/303