### PR TITLE
mirage-solo5: depend on mirage-runtime, not mirage

### DIFF
--- a/packages/functoria-runtime/functoria-runtime.4.0.0/opam
+++ b/packages/functoria-runtime/functoria-runtime.4.0.0/opam
@@ -12,24 +12,20 @@ license:      "ISC"
 tags:         ["org:mirage"]
 
 build: [
-  ["dune" "subst"]
+  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["env" "INSIDE_FUNCTORIA_TESTS=1" "dune" "exec" "-p" name "-j" jobs "--"
+     "test/functoria/e2e/test.exe"] {with-test}
 ]
 
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "base-unix"
   "cmdliner" {>= "0.9.8"}
-  "rresult"
-  "astring"
   "fmt"
-  "ocamlgraph"
-  "logs"
-  "bos"
-  "fpath"
   "alcotest" {with-test}
+  "functoria" {with-test & >= "2.2.0"}
 ]
 synopsis: "A DSL to organize functor applications"
 description: """

--- a/packages/functoria/functoria.4.0.0/opam
+++ b/packages/functoria/functoria.4.0.0/opam
@@ -12,20 +12,19 @@ license:      "ISC"
 tags:         ["org:mirage"]
 
 build: [
-  ["dune" "subst"]
+  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
   "base-unix"
   "cmdliner" {>= "0.9.8"}
   "rresult"
   "astring"
   "fmt"
-  "ocamlgraph"
   "logs"
   "bos"
   "fpath"

--- a/packages/mirage-runtime/mirage-runtime.4.0.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.4.0.0/opam
@@ -10,24 +10,20 @@ tags:         ["org:mirage" "org:xapi-project"]
 doc:          "https://mirage.github.io/mirage/"
 
 build: [
-  ["dune" "subst"]
+  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
   "ipaddr"             {>= "5.0.0"}
   "functoria-runtime"  {>= "3.0.2"}
-  "fmt"
+  "fmt" {>= "0.8.4"}
   "logs"
   "lwt" {>= "4.0.0"}
   "alcotest" {with-test}
-]
-conflicts: [
-  "parsexp" { < "v0.14.0"}
-  "sexplib" { < "v0.14.0"}
 ]
 synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
 description: """

--- a/packages/mirage-solo5/mirage-solo5.0.7.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.7.0/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
-  ("ocaml-freestanding" {>= "0.4.5"} | "mirage" {>= "4.0.0"})
+  ("ocaml-freestanding" {>= "0.4.5"} | "mirage-runtime" {>= "4.0.0"})
   "metrics"
   "mirage-runtime" {>= "3.7.0"}
   "duration"

--- a/packages/mirage-solo5/mirage-solo5.0.7.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.7.0/opam
@@ -30,7 +30,7 @@ depends: [
   "metrics"
   "mirage-runtime" {>= "3.7.0"}
   "duration"
-  ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"} | "mirage" {>= "4.0.0"})
+  ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"} | "mirage-runtime" {>= "4.0.0"})
 ]
 conflicts: [
   "io-page" {< "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.7.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.7.0.0/opam
@@ -27,7 +27,7 @@ depends: [
   "logs"
   "fmt"
   ("ocaml-freestanding" {>= "0.6.2"} & 
-  "solo5-bindings-xen" {>= "0.6.7"}) | "mirage" {>= "4.0.0"}
+  "solo5-bindings-xen" {>= "0.6.7"}) | "mirage-runtime" {>= "4.0.0"}
   "bheap" {>= "2.0.0"}
   "duration"
 ]

--- a/packages/mirage-xen/mirage-xen.7.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.7.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "mirage-runtime" {>= "3.7.0"}
   "logs"
   "fmt"
-  ("ocaml-freestanding" {>= "0.6.2"} & 
+  ("ocaml-freestanding" {>= "0.6.2"} &
   "solo5-bindings-xen" {>= "0.6.7"}) | "mirage-runtime" {>= "4.0.0"}
   "bheap" {>= "2.0.0"}
   "duration"


### PR DESCRIPTION
this is basically what we applied to mirage-crypto-pk as well, otherwise a unikernel will depend on mirage+friends