### PR TITLE
Update base fork to v0.14.2

### DIFF
--- a/packages/base/base.v0.14.2/opam
+++ b/packages/base/base.v0.14.2/opam
@@ -31,5 +31,5 @@ provided by companion libraries such as stdio:
   https://github.com/janestreet/stdio
 "
 url {
- src: "https://github.com/TheLortex/base/archive/v0.14.1.zip"
+ src: "https://github.com/TheLortex/base/archive/v0.14.2+fix-dep.zip"
 }


### PR DESCRIPTION
`base.v0.14.2` was released to support OCaml 4.14.0 (https://github.com/janestreet/base/pull/124). As a consequence the fork needed to be rebased to take that change into account.