### PR TITLE
Rename the freestanding context to solo5 for mirage-{console,net,block}-solo5

### DIFF
--- a/packages/digestif/digestif.1.1.1/opam
+++ b/packages/digestif/digestif.1.1.1/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/digestif"
+bug-reports:  "https://github.com/mirage/digestif/issues"
+dev-repo:     "git+https://github.com/mirage/digestif.git"
+doc:          "https://mirage.github.io/digestif/"
+license:      "MIT"
+synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+description: """
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "./install/install.ml" ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+install:  [
+  [ "dune" "install" "-p" name ] {with-test}
+  [ "./test/test_runes.ml" ] {with-test}
+]
+
+depends: [
+  "ocaml"           {>= "4.05.0"}
+  "dune"            {>= "2.6.0"}
+  "conf-pkg-config" {build}
+  "eqaf"
+  "base-bytes"
+  "bigarray-compat"
+  "stdlib-shims"
+  "fmt"            {with-test}
+  "alcotest"       {with-test}
+  "bos"            {with-test}
+  "astring"        {with-test}
+  "fpath"          {with-test}
+  "rresult"        {with-test}
+  "ocamlfind"      {with-test}
+]
+depopts: [
+  "ocaml-freestanding"
+]
+
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.6.0"}
+]
+url {
+  src: "git+https://github.com/mirage/digestif.git#d1e1a69d4d0356e993e5c496d7b08d9ad11227d4"
+}
+x-commit-hash: "d1e1a69d4d0356e993e5c496d7b08d9ad11227d4"

--- a/packages/mirage-block-solo5/mirage-block-solo5.0.8.0/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.8.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-block-solo5"
+dev-repo:     "git+https://github.com/mirage/mirage-block-solo5.git"
+bug-reports:  "https://github.com/mirage/mirage-block-solo5/issues"
+doc:           "https://mirage.github.io/mirage-block-solo5/"
+license:       "ISC"
+authors:      ["Dan Williams" "Martin Lucina"]
+tags: [
+  "org:mirage"
+]
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "2.0"}
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-solo5" {>= "0.8.0"}
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Solo5 implementation of MirageOS block interface"
+description:
+  "This library implements the MirageOS block interface for Solo5 targets."
+url {
+  src: "git+https://github.com/mirage/mirage-block-solo5.git#7030ca85ec98844d932a97f6cd7093b283d5c662"
+}
+x-commit-hash: "7030ca85ec98844d932a97f6cd7093b283d5c662"

--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.6.0/opam
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Martin Lucina <martin@lucina.net>"
+homepage:     "https://github.com/mirage/mirage-bootvar-solo5"
+bug-reports:  "https://github.com/mirage/mirage-bootvar-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-bootvar-solo5.git"
+license:      "ISC"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Magnus Skjegstad <magnus@skjegstad.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.9.0"}
+  "lwt"
+  "parse-argv"
+]
+synopsis: "Solo5 implementation of MirageOS Bootvar interface"
+url {
+  src:
+    "https://github.com/mirage/mirage-bootvar-solo5/releases/download/v0.6.0/mirage-bootvar-solo5-v0.6.0.tbz"
+  checksum: [
+    "sha256=113ea304f8c418d3045aa9611492d200ec8ce3b06c40a91b0aa3ca190d691737"
+    "sha512=4966c100f8ee87537e586a1a305d8c706baa36ce5c208dce2ae89cc101d4faa458fa3b10e7b79b42b412137d81c7f56676d89e6fde1d955ec1d609538e9b04e0"
+  ]
+}

--- a/packages/mirage-clock-solo5/mirage-clock-solo5.4.2.0/opam
+++ b/packages/mirage-clock-solo5/mirage-clock-solo5.4.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Paravirtual implementation of the MirageOS Clock interface"
+description: """
+This 'freestanding' implementation of the MirageOS CLOCK interface
+is designed to be linked against an embedded runtime that provides
+a concrete implementation of the clock source. Example implementations
+include the [Solo5](https://github.com/solo5/solo5) backend of
+MirageOS.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "mirage-clock" {= version}
+]
+conflicts: [
+  "mirage-solo5" {< "0.7.0"}
+  "mirage-xen" {< "7.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src: "git+https://github.com/mirage/mirage-clock.git#2726b3780d0db0582ba2beaa2307201f3b015b16"
+}
+x-commit-hash: "2726b3780d0db0582ba2beaa2307201f3b015b16"

--- a/packages/mirage-clock-unix/mirage-clock-unix.4.2.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.4.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Unix-based implementation for the MirageOS Clock interface"
+description: """
+The Unix implementation of the MirageOS Clock interface uses
+`gettimeofday` or `clock_gettime`, depending on
+which OS is in use (see [clock_stubs.c](https://github.com/mirage/mirage-clock/blob/master/unix/clock_stubs.c)).
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "dune-configurator"
+  "mirage-clock" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src: "git+https://github.com/mirage/mirage-clock.git#2726b3780d0db0582ba2beaa2307201f3b015b16"
+}
+x-commit-hash: "2726b3780d0db0582ba2beaa2307201f3b015b16"

--- a/packages/mirage-clock/mirage-clock.4.2.0/opam
+++ b/packages/mirage-clock/mirage-clock.4.2.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Libraries and module types for portable clocks"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirage.io) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements an `MCLOCK` module that represents a monotonic timesource
+since an arbitrary point, and `PCLOCK` which counts time since the Unix
+epoch.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src: "git+https://github.com/mirage/mirage-clock.git#2726b3780d0db0582ba2beaa2307201f3b015b16"
+}
+x-commit-hash: "2726b3780d0db0582ba2beaa2307201f3b015b16"

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.8.0/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.8.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-console-solo5"
+bug-reports:   "https://github.com/mirage/mirage-console-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-console-solo5.git"
+doc:           "https://mirage.github.io/mirage-console-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "mirage-console" {>= "3.0.0"}
+  "mirage-solo5" {>= "0.8.0"}
+  "cstruct"
+  "lwt"
+]
+synopsis: "Solo5 implementation of MirageOS console interface"
+description:
+  "This library implements the MirageOS console interface for Solo5 targets."
+url {
+  src: "git+https://github.com/mirage/mirage-console-solo5.git#36722e7a6ab36f2b112276bf3cd4838524bbc0f1"
+}
+x-commit-hash: "36722e7a6ab36f2b112276bf3cd4838524bbc0f1"

--- a/packages/mirage-net-solo5/mirage-net-solo5.0.8.0/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.8.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-net-solo5"
+bug-reports:   "https://github.com/mirage/mirage-net-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-solo5.git"
+doc:           "https://mirage.github.io/mirage-net-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "macaddr" { >= "4.0.0"}
+  "mirage-solo5" {>= "0.8.0"}
+  "logs" {>= "0.6.0"}
+  "metrics"
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Solo5 implementation of MirageOS network interface"
+description:
+  "This library implements the MirageOS network interface for Solo5 targets."
+url {
+  src: "git+https://github.com/mirage/mirage-net-solo5.git#167ecb20f0750c1d34f801da69b01c808a6fab80"
+}
+x-commit-hash: "167ecb20f0750c1d34f801da69b01c808a6fab80"

--- a/packages/mirage-solo5/mirage-solo5.0.8.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.8.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bheap" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "metrics"
+  "mirage-runtime" {>= "4.0"}
+  "duration"
+]
+conflicts: [
+  "io-page" {< "2.4.0"}
+  "tcpip" {< "6.1.0"}
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+url {
+  src: "git+https://github.com/mirage/mirage-solo5.git#67b888803f9f0bbf366d993d99b9ef65d5c062a4"
+}
+x-commit-hash: "67b888803f9f0bbf366d993d99b9ef65d5c062a4"

--- a/packages/mirage-xen/mirage-xen.7.1.0/opam
+++ b/packages/mirage-xen/mirage-xen.7.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "io-page" {>= "2.4.0"}
+  "mirage-runtime" {>= "4.0"}
+  "logs"
+  "fmt" {>= "0.8.5"}
+  "bheap" {>= "2.0.0"}
+  "duration"
+]
+available: [
+  (arch = "x86_64" ) &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src: "git+https://github.com/mirage/mirage-xen.git#a7b1d5eb5deb499cd76b174b602cdeff2c752fd1"
+}
+x-commit-hash: "a7b1d5eb5deb499cd76b174b602cdeff2c752fd1"


### PR DESCRIPTION
https://github.com/mirage/mirage-solo5/pull/85
https://github.com/mirage/mirage-net-solo5/pull/43
https://github.com/mirage/mirage-block-solo5/pull/24
https://github.com/mirage/mirage-console-solo5/pull/23
https://github.com/mirage/mirage-clock/pull/52
https://github.com/mirage/mirage-xen/pull/40